### PR TITLE
expose tools for Bitquery Solana agent and Coingecko agent

### DIFF
--- a/mesh/bitquery_sol_token_info_agent.py
+++ b/mesh/bitquery_sol_token_info_agent.py
@@ -26,19 +26,6 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
                     'required': True
                 },
                 {
-                    'name': 'tool',
-                    'description': 'Directly specify which tool to call (e.g., "get_token_trading_info", "get_top_trending_tokens"). Bypasses LLM.',
-                    'type': 'str',
-                    'required': False
-                },
-                {
-                    'name': 'tool_arguments',
-                    'description': 'Arguments for the tool call, e.g., {"token_address":"Mint_Address"}.',
-                    'type': 'dict',
-                    'required': False,
-                    'default': {}
-                },
-                {
                     'name': 'raw_data_only',
                     'description': 'If true, the agent will only return the raw data and not the full response',
                     'type': 'bool',
@@ -191,6 +178,102 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
             return {"trending_tokens": trending_tokens}
         except Exception as e:
             return {"error": f"Failed to fetch top trending tokens: {str(e)}"}
+
+    # ------------------------------------------------------------------------
+    #                      COMMON HANDLER LOGIC
+    # ------------------------------------------------------------------------
+    async def _handle_tool_logic(
+        self, tool_name: str, function_args: dict, query: str, tool_call_id: str, raw_data_only: bool
+    ) -> Dict[str, Any]:
+        """
+        A single method that calls the appropriate function, handles
+        errors/formatting, and optionally calls the LLM to explain the result.
+        """
+        temp = 0.7
+
+        if tool_name == 'get_token_trading_info':
+            result = await self.get_token_trading_info(function_args['token_address'])
+        elif tool_name == 'get_top_trending_tokens':
+            result = await self.get_top_trending_tokens()
+        else:
+            return {"error": f"Unsupported tool: {tool_name}"}
+
+        errors = self._handle_error(result)
+        if errors:
+            return errors
+
+        if raw_data_only:
+            return {"response": "", "data": result}
+
+        explanation = await self._respond_with_llm(
+            query=query,
+            tool_call_id=tool_call_id,
+            data=result,
+            temperature=temp
+        )
+
+        return {"response": explanation, "data": result}
+
+    @monitor_execution()
+    @with_retry(max_retries=3)
+    async def handle_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Either 'query' or 'tool' is required in params.
+          - If 'tool' is provided, call that tool directly with 'tool_arguments' (bypassing the LLM).
+          - If 'query' is provided, route via LLM for dynamic tool selection.
+        """
+        query = params.get('query')
+        tool_name = params.get('tool')
+        tool_args = params.get('tool_arguments', {})
+        raw_data_only = params.get('raw_data_only', False)
+        query = params.get('query')
+
+        # ---------------------
+        # 1) DIRECT TOOL CALL
+        # ---------------------
+        if tool_name:
+            return await self._handle_tool_logic(
+                tool_name=tool_name,
+                function_args=tool_args,
+                query=query or "Direct tool call without LLM.",
+                tool_call_id="direct_tool",
+                raw_data_only=raw_data_only
+            )
+
+        # ---------------------
+        # 2) NATURAL LANGUAGE QUERY (LLM decides the tool)
+        # --------------------- 
+        if query:
+            response = await call_llm_with_tools_async(
+                base_url=self.heurist_base_url,
+                api_key=self.heurist_api_key,
+                model_id=self.metadata['large_model_id'],
+                system_prompt=self.get_system_prompt(),
+                user_prompt=query,
+                temperature=0.1,
+                tools=self.get_tool_schemas()
+            )
+
+            if not response:
+                return {"error": "Failed to process query"}
+
+            if not response.get('tool_calls'):
+                # No tool calls => the LLM just answered
+                return {"response": response['content'], "data": {}}
+
+            tool_call = response['tool_calls']
+            tool_call_name = tool_call.function.name
+            tool_call_args = json.loads(tool_call.function.arguments)
+
+            return await self._handle_tool_logic(
+                tool_name=tool_call_name,
+                function_args=tool_call_args,
+                query=query,
+                tool_call_id=tool_call.id,
+                raw_data_only=raw_data_only
+            )
+
+        return {"error": "Either 'query' or 'tool' must be provided in the parameters."}
 
 def fetch_and_organize_dex_trade_data(base_address: str) -> List[Dict]:
     """
@@ -487,100 +570,3 @@ def top_ten_trending_tokens():
         organized_data.append(organized_item)
 
     return organized_data
-
-
-    # ------------------------------------------------------------------------
-    #                      COMMON HANDLER LOGIC
-    # ------------------------------------------------------------------------
-    async def _handle_tool_logic(
-        self, tool_name: str, function_args: dict, query: str, tool_call_id: str, raw_data_only: bool
-    ) -> Dict[str, Any]:
-        """
-        A single method that calls the appropriate function, handles
-        errors/formatting, and optionally calls the LLM to explain the result.
-        """
-        temp = 0.7
-
-        if tool_name == 'get_token_trading_info':
-            result = await self.get_token_trading_info(function_args['token_address'])
-        elif tool_name == 'get_top_trending_tokens':
-            result = await self.get_top_trending_tokens()
-        else:
-            return {"error": f"Unsupported tool: {tool_name}"}
-
-        errors = self._handle_error(result)
-        if errors:
-            return errors
-
-        if raw_data_only:
-            return {"response": "", "data": result}
-
-        explanation = await self._respond_with_llm(
-            query=query,
-            tool_call_id=tool_call_id,
-            data=result,
-            temperature=temp
-        )
-
-        return {"response": explanation, "data": result}
-
-    @monitor_execution()
-    @with_retry(max_retries=3)
-    async def handle_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Either 'query' or 'tool' is required in params.
-          - If 'tool' is provided, call that tool directly with 'tool_arguments' (bypassing the LLM).
-          - If 'query' is provided, route via LLM for dynamic tool selection.
-        """
-        query = params.get('query')
-        tool_name = params.get('tool')
-        tool_args = params.get('tool_arguments', {})
-        raw_data_only = params.get('raw_data_only', False)
-        query = params.get('query')
-
-        # ---------------------
-        # 1) DIRECT TOOL CALL
-        # ---------------------
-        if tool_name:
-            return await self._handle_tool_logic(
-                tool_name=tool_name,
-                function_args=tool_args,
-                query=query or "Direct tool call without LLM.",
-                tool_call_id="direct_tool",
-                raw_data_only=raw_data_only
-            )
-
-        # ---------------------
-        # 2) NATURAL LANGUAGE QUERY (LLM decides the tool)
-        # --------------------- 
-        if query:
-            response = await call_llm_with_tools_async(
-                base_url=self.heurist_base_url,
-                api_key=self.heurist_api_key,
-                model_id=self.metadata['large_model_id'],
-                system_prompt=self.get_system_prompt(),
-                user_prompt=query,
-                temperature=0.1,
-                tools=self.get_tool_schemas()
-            )
-
-            if not response:
-                return {"error": "Failed to process query"}
-
-            if not response.get('tool_calls'):
-                # No tool calls => the LLM just answered
-                return {"response": response['content'], "data": {}}
-
-            tool_call = response['tool_calls']
-            tool_call_name = tool_call.function.name
-            tool_call_args = json.loads(tool_call.function.arguments)
-
-            return await self._handle_tool_logic(
-                tool_name=tool_call_name,
-                function_args=tool_call_args,
-                query=query,
-                tool_call_id=tool_call.id,
-                raw_data_only=raw_data_only
-            )
-
-        return {"error": "Either 'query' or 'tool' must be provided in the parameters."}

--- a/mesh/bitquery_sol_token_info_agent.py
+++ b/mesh/bitquery_sol_token_info_agent.py
@@ -26,6 +26,19 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
                     'required': True
                 },
                 {
+                    'name': 'tool',
+                    'description': 'Directly specify which tool to call (e.g., "get_token_trading_info", "get_top_trending_tokens"). Bypasses LLM.',
+                    'type': 'str',
+                    'required': False
+                },
+                {
+                    'name': 'tool_arguments',
+                    'description': 'Arguments for the tool call, e.g., {"token_address":"Mint_Address"}.',
+                    'type': 'dict',
+                    'required': False,
+                    'default': {}
+                },
+                {
                     'name': 'raw_data_only',
                     'description': 'If true, the agent will only return the raw data and not the full response',
                     'type': 'bool',
@@ -67,7 +80,7 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
             "   - Trading volume\n"
             "   - Number of trades\n"
             "   - Exchange names\n"
-            "For any token contract address, you MUST use this format [Mint Address](https://solscan.io/token/Mint Address)"
+            "For any token contract address, you MUST use this format [Mint Address](https://solscan.io/token/Mint_Address)"
         )
 
     def get_tool_schemas(self) -> List[Dict]:
@@ -93,7 +106,7 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
                 'type': 'function',
                 'function': {
                     'name': 'get_top_trending_tokens',
-                    'description': 'Get the current top trending tokens on the Solana network',
+                    'description': 'Get the current top trending tokens on Solana',
                     'parameters': {
                         'type': 'object',
                         'properties': {},
@@ -102,6 +115,41 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
                 }
             }
         ]
+
+    # ------------------------------------------------------------------------
+    #                       SHARED / UTILITY METHODS
+    # ------------------------------------------------------------------------
+    async def _respond_with_llm(
+        self, query: str, tool_call_id: str, data: dict, temperature: float
+    ) -> str:
+        """
+        Reusable helper to ask the LLM to generate a user-friendly explanation
+        given a piece of data from a tool call.
+        """
+        return await call_llm_async(
+            base_url=self.heurist_base_url,
+            api_key=self.heurist_api_key,
+            model_id=self.metadata['large_model_id'],
+            messages=[
+                {"role": "system", "content": self.get_system_prompt()},
+                {"role": "user", "content": query},
+                {"role": "tool", "content": str(data), "tool_call_id": tool_call_id}
+            ],
+            temperature=temperature
+        )
+
+    def _handle_error(self, maybe_error: dict) -> dict:
+        """
+        Small helper to return the error if present in
+        a dictionary with the 'error' key.
+        """
+        if 'error' in maybe_error:
+            return {"error": maybe_error['error']}
+        return {}
+
+    # ------------------------------------------------------------------------
+    #                      API-SPECIFIC METHODS
+    # ------------------------------------------------------------------------
 
     @with_cache(ttl_seconds=300)  # Cache for 5 minutes
     async def get_token_trading_info(self, token_address: str) -> Dict:
@@ -144,89 +192,6 @@ class BitquerySolanaTokenInfoAgent(MeshAgent):
         except Exception as e:
             return {"error": f"Failed to fetch top trending tokens: {str(e)}"}
 
-    @monitor_execution()
-    @with_retry(max_retries=3)
-    async def handle_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        query = params.get('query')
-        if not query:
-            raise ValueError("Query parameter is required")
-
-        response = await call_llm_with_tools_async(
-            base_url=self.heurist_base_url,
-            api_key=self.heurist_api_key,
-            model_id=self.metadata['large_model_id'],
-            system_prompt=self.get_system_prompt(),
-            user_prompt=query,
-            temperature=0.1,
-            tools=self.get_tool_schemas()
-        )
-
-        if not response:
-            return {"error": "Failed to process query"}
-
-        if not response.get('tool_calls'):
-            return {"response": response['content'], "data": {}}
-
-        tool_call = response['tool_calls']
-        function_args = json.loads(tool_call.function.arguments)
-
-        if tool_call.function.name == 'get_token_trading_info':
-            token_address = function_args['token_address']
-            trading_info = await self.get_token_trading_info(token_address)
-            raw_data_only = params.get('raw_data_only', False)
-
-            if 'error' in trading_info:
-                return { "error": f"Error fetching token trading info: {trading_info['error']}" }
-
-            if raw_data_only:
-                return { "response": "", "data": trading_info }
-
-            explanation = await call_llm_async(
-                base_url=self.heurist_base_url,
-                api_key=self.heurist_api_key,
-                model_id=self.metadata['large_model_id'],
-                messages=[
-                    {"role": "system", "content": self.get_system_prompt()},
-                    {"role": "user", "content": query},
-                    {"role": "tool", "content": str(trading_info), "tool_call_id": tool_call.id}
-                ],
-                temperature=0.7
-            )
-
-            return {
-                "response": explanation,
-                "data": trading_info
-            }
-
-        elif tool_call.function.name == 'get_top_trending_tokens':
-            trending_results = await self.get_top_trending_tokens()
-            if 'error' in trending_results:
-                return { "error": f"Error fetching top trending tokens: {trending_results['error']}" }
-
-            raw_data_only = params.get('raw_data_only', False)
-            if raw_data_only:
-                return { "response": "", "data": trending_results }
-
-            explanation = await call_llm_async(
-                base_url=self.heurist_base_url,
-                api_key=self.heurist_api_key,
-                model_id=self.metadata['large_model_id'],
-                messages=[
-                    {"role": "system", "content": self.get_system_prompt()},
-                    {"role": "user", "content": query},
-                    {"role": "tool", "content": str(trending_results), "tool_call_id": tool_call.id}
-                ],
-                temperature=0.3
-            )
-
-            return {
-                "response": explanation,
-                "data": trending_results
-            }
-
-        return {"error": "Unsupported operation"}
-
-# ------------------------- Helper Functions ------------------------- #
 def fetch_and_organize_dex_trade_data(base_address: str) -> List[Dict]:
     """
     Fetches DEX trade data from Bitquery for the given base token address,
@@ -523,3 +488,99 @@ def top_ten_trending_tokens():
 
     return organized_data
 
+
+    # ------------------------------------------------------------------------
+    #                      COMMON HANDLER LOGIC
+    # ------------------------------------------------------------------------
+    async def _handle_tool_logic(
+        self, tool_name: str, function_args: dict, query: str, tool_call_id: str, raw_data_only: bool
+    ) -> Dict[str, Any]:
+        """
+        A single method that calls the appropriate function, handles
+        errors/formatting, and optionally calls the LLM to explain the result.
+        """
+        temp = 0.7
+
+        if tool_name == 'get_token_trading_info':
+            result = await self.get_token_trading_info(function_args['token_address'])
+        elif tool_name == 'get_top_trending_tokens':
+            result = await self.get_top_trending_tokens()
+        else:
+            return {"error": f"Unsupported tool: {tool_name}"}
+
+        errors = self._handle_error(result)
+        if errors:
+            return errors
+
+        if raw_data_only:
+            return {"response": "", "data": result}
+
+        explanation = await self._respond_with_llm(
+            query=query,
+            tool_call_id=tool_call_id,
+            data=result,
+            temperature=temp
+        )
+
+        return {"response": explanation, "data": result}
+
+    @monitor_execution()
+    @with_retry(max_retries=3)
+    async def handle_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Either 'query' or 'tool' is required in params.
+          - If 'tool' is provided, call that tool directly with 'tool_arguments' (bypassing the LLM).
+          - If 'query' is provided, route via LLM for dynamic tool selection.
+        """
+        query = params.get('query')
+        tool_name = params.get('tool')
+        tool_args = params.get('tool_arguments', {})
+        raw_data_only = params.get('raw_data_only', False)
+        query = params.get('query')
+
+        # ---------------------
+        # 1) DIRECT TOOL CALL
+        # ---------------------
+        if tool_name:
+            return await self._handle_tool_logic(
+                tool_name=tool_name,
+                function_args=tool_args,
+                query=query or "Direct tool call without LLM.",
+                tool_call_id="direct_tool",
+                raw_data_only=raw_data_only
+            )
+
+        # ---------------------
+        # 2) NATURAL LANGUAGE QUERY (LLM decides the tool)
+        # --------------------- 
+        if query:
+            response = await call_llm_with_tools_async(
+                base_url=self.heurist_base_url,
+                api_key=self.heurist_api_key,
+                model_id=self.metadata['large_model_id'],
+                system_prompt=self.get_system_prompt(),
+                user_prompt=query,
+                temperature=0.1,
+                tools=self.get_tool_schemas()
+            )
+
+            if not response:
+                return {"error": "Failed to process query"}
+
+            if not response.get('tool_calls'):
+                # No tool calls => the LLM just answered
+                return {"response": response['content'], "data": {}}
+
+            tool_call = response['tool_calls']
+            tool_call_name = tool_call.function.name
+            tool_call_args = json.loads(tool_call.function.arguments)
+
+            return await self._handle_tool_logic(
+                tool_name=tool_call_name,
+                function_args=tool_call_args,
+                query=query,
+                tool_call_id=tool_call.id,
+                raw_data_only=raw_data_only
+            )
+
+        return {"error": "Either 'query' or 'tool' must be provided in the parameters."}

--- a/mesh/coingecko_token_info_agent.py
+++ b/mesh/coingecko_token_info_agent.py
@@ -28,20 +28,6 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
                     'required': False
                 },
                 {
-                    'name': 'tool',
-                    'description': 'Directly specify which tool to call (e.g., "get_trending_coins", '
-                                   '"get_token_info", or "get_coingecko_id"). Bypasses LLM.',
-                    'type': 'str',
-                    'required': False
-                },
-                {
-                    'name': 'tool_arguments',
-                    'description': 'Arguments for the tool call, e.g., {"coingecko_id":"bitcoin"}.',
-                    'type': 'dict',
-                    'required': False,
-                    'default': {}
-                },
-                {
                     'name': 'raw_data_only',
                     'description': 'If true, the agent will only return the raw or base structured data without additional LLM explanation.',
                     'type': 'bool',

--- a/mesh/coingecko_token_info_agent.py
+++ b/mesh/coingecko_token_info_agent.py
@@ -19,17 +19,31 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
             'version': '1.0.0',
             'author': 'Heurist team',
             'author_address': '0x7d9d1821d15B9e0b8Ab98A058361233E255E405D',
-            'description': 'This agent can fetch token information and trending coins from CoinGecko',
+            'description': 'This agent can fetch token information, market data, and trending coins from CoinGecko. ',
             'inputs': [
                 {
                     'name': 'query',
-                    'description': 'Natural language query about a token, or a request for trending coins. If querying a specific token, use CoinGecko ID or token name or symbol.',
+                    'description': 'Natural language query about a token, or a request for trending coins. ',
                     'type': 'str',
-                    'required': True
+                    'required': False
+                },
+                {
+                    'name': 'tool',
+                    'description': 'Directly specify which tool to call (e.g., "get_trending_coins", '
+                                   '"get_token_info", or "get_coingecko_id"). Bypasses LLM.',
+                    'type': 'str',
+                    'required': False
+                },
+                {
+                    'name': 'tool_arguments',
+                    'description': 'Arguments for the tool call, e.g., {"coingecko_id":"bitcoin"}.',
+                    'type': 'dict',
+                    'required': False,
+                    'default': {}
                 },
                 {
                     'name': 'raw_data_only',
-                    'description': 'If true, the agent will only return the raw data and not the full response',
+                    'description': 'If true, the agent will only return the raw or base structured data without additional LLM explanation.',
                     'type': 'bool',
                     'required': False,
                     'default': False
@@ -38,12 +52,12 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
             'outputs': [
                 {
                     'name': 'response',
-                    'description': 'Natural language explanation of the token information',
+                    'description': 'Natural language explanation of the token information (empty if a direct tool call).',
                     'type': 'str'
                 },
                 {
                     'name': 'data',
-                    'description': 'Structured token information or trending coins data',
+                    'description': 'Structured token information or trending coins data.',
                     'type': 'dict'
                 }
             ],
@@ -83,7 +97,7 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
                 'type': 'function',
                 'function': {
                     'name': 'get_token_info',
-                    'description': 'Get detailed token information using CoinGecko ID',
+                    'description': 'Get detailed token information and market data using CoinGecko ID',
                     'parameters': {
                         'type': 'object',
                         'properties': {
@@ -100,7 +114,7 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
                 'type': 'function',
                 'function': {
                     'name': 'get_trending_coins',
-                    'description': 'Get the current top trending cryptocurrencies',
+                    'description': 'Get the current top trending cryptocurrencies on CoinGecko',
                     'parameters': {
                         'type': 'object',
                         'properties': {},
@@ -110,8 +124,42 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
             }
         ]
 
+    # ------------------------------------------------------------------------
+    #                       SHARED / UTILITY METHODS
+    # ------------------------------------------------------------------------
+    async def _respond_with_llm(
+        self, query: str, tool_call_id: str, data: dict, temperature: float
+    ) -> str:
+        """
+        Reusable helper to ask the LLM to generate a user-friendly explanation
+        given a piece of data from a tool call.
+        """
+        return await call_llm_async(
+            base_url=self.heurist_base_url,
+            api_key=self.heurist_api_key,
+            model_id=self.metadata['large_model_id'],
+            messages=[
+                {"role": "system", "content": self.get_system_prompt()},
+                {"role": "user", "content": query},
+                {"role": "tool", "content": str(data), "tool_call_id": tool_call_id}
+            ],
+            temperature=temperature
+        )
+
+    def _handle_error(self, maybe_error: dict) -> dict:
+        """
+        Small helper to return the error if present in
+        a dictionary with the 'error' key.
+        """
+        if 'error' in maybe_error:
+            return {"error": maybe_error['error']}
+        return {}
+
+    # ------------------------------------------------------------------------
+    #                      COINGECKO API-SPECIFIC METHODS
+    # ------------------------------------------------------------------------
     @with_cache(ttl_seconds=300)  # Cache for 5 minutes
-    async def get_trending_coins(self):
+    async def get_trending_coins(self) -> dict:
         try:
             response = requests.get(
                 f"{self.api_url}/search/trending",
@@ -136,123 +184,38 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
             print(f"error: {e}")
             return {"error": f"Failed to fetch trending coins: {str(e)}"}
 
-    @monitor_execution()
-    @with_retry(max_retries=3)
-    async def handle_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        query = params.get('query')
-        if not query:
-            raise ValueError("Query parameter is required")
-
-        response = await call_llm_with_tools_async(
-            base_url=self.heurist_base_url,
-            api_key=self.heurist_api_key,
-            model_id=self.metadata['large_model_id'],
-            system_prompt=self.get_system_prompt(),
-            user_prompt=query,
-            temperature=0.1,
-            tools=self.get_tool_schemas()
-        )
-        
-        if not response:
-            return {"error": "Failed to process query"}
-
-        if not response.get('tool_calls'):
-            return {"response": response['content'], "data": {}}
-
-        tool_call = response['tool_calls']
-        function_args = json.loads(tool_call.function.arguments)
-
-        if tool_call.function.name == 'get_trending_coins':
-            trending_results = await self.get_trending_coins()
-            if 'error' in trending_results:
-                return { "error": f"Error fetching trending coins: {trending_results['error']}" }
-
-            raw_data_only = params.get('raw_data_only', False)
-            if raw_data_only:
-                return {"response": "", "data": trending_results}
-
-            explanation = await call_llm_async(
-                base_url=self.heurist_base_url,
-                api_key=self.heurist_api_key,
-                model_id=self.metadata['large_model_id'],
-                messages=[
-                    {"role": "system", "content": self.get_system_prompt()},
-                    {"role": "user", "content": query},
-                    {"role": "tool", "content": str(trending_results), "tool_call_id": tool_call.id}
-                ],
-                temperature=0.3
+    @with_cache(ttl_seconds=3600)
+    async def get_coingecko_id(self, token_name: str) -> dict | str:
+        try:
+            response = requests.get(
+                f"{self.api_url}/search?query={token_name}",
+                headers=self.headers
             )
+            response.raise_for_status()
+            search_results = response.json()
+            print(f"search_results: {search_results}")
+            # Return the first coin id if found
+            if search_results.get('coins'):
+                first_coin = search_results['coins'][0]
+                return first_coin['id']
+            return {"error": "No matching token found on CoinGecko"}
             
-            return {
-                "response": explanation,
-                "data": trending_results
-            }
-            
-        elif tool_call.function.name == 'get_coingecko_id':
-            token_name = function_args['token_name']
-            coingecko_id = await self.get_coingecko_id(token_name)
-            if isinstance(coingecko_id, dict) and 'error' in coingecko_id:
-                return { "error": f"Error fetching CoinGecko ID: {coingecko_id['error']}" }
-            
-            # Get token info using the found coingecko_id
-            token_info = await self.get_token_info(coingecko_id)
-            if 'error' in token_info:
-                return { "error": f"Error fetching token info: {token_info['error']}" }
-                
-            formatted_data = self.format_token_info(token_info)
-            
-            raw_data_only = params.get('raw_data_only', False)
-            if raw_data_only:
-                return {"response": "", "data": formatted_data}
-            
-            explanation = await call_llm_async(
-                base_url=self.heurist_base_url,
-                api_key=self.heurist_api_key,
-                model_id=self.metadata['large_model_id'],
-                messages=[
-                    {"role": "system", "content": self.get_system_prompt()},
-                    {"role": "user", "content": query},
-                    {"role": "tool", "content": str(formatted_data), "tool_call_id": tool_call.id}
-                ],
-                temperature=0.7
-            )
-            
-            return {
-                "response": explanation,
-                "data": formatted_data
-            }
-            
-        elif tool_call.function.name == 'get_token_info':
-            coingecko_id = function_args['coingecko_id']
-            token_info = await self.get_token_info(coingecko_id)
-            
-            if 'error' in token_info:
-                return { "error": f"Error fetching token info: {token_info['error']}" }
-                
-            formatted_data = self.format_token_info(token_info)
-            
-            raw_data_only = params.get('raw_data_only', False)
-            if raw_data_only:
-                return {"response": "", "data": formatted_data}
-            
-            explanation = await call_llm_async(
-                base_url=self.heurist_base_url,
-                api_key=self.heurist_api_key,
-                model_id=self.metadata['large_model_id'],
-                messages=[
-                    {"role": "system", "content": self.get_system_prompt()},
-                    {"role": "user", "content": query},
-                    {"role": "tool", "content": str(formatted_data), "tool_call_id": tool_call.id}
-                ],
-                temperature=0.7
-            )
-            
-            return {
-                "response": explanation,
-                "data": formatted_data
-            }
+        except requests.RequestException as e:
+            print(f"error: {e}")
+            return {"error": f"Failed to search for token: {str(e)}"}
 
-        return {"error": "Unsupported operation"}
+    @with_cache(ttl_seconds=3600)
+    async def get_token_info(self, coingecko_id: str) -> dict:
+        try:
+            response = requests.get(
+                f"{self.api_url}/coins/{coingecko_id}",
+                headers=self.headers
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            print(f"error: {e}")
+            return {"error": f"Failed to fetch token info: {str(e)}"}
 
     def format_token_info(self, data: Dict) -> Dict:
         """Format token information in a structured way"""
@@ -287,33 +250,152 @@ class CoinGeckoTokenInfoAgent(MeshAgent):
             }
         }
 
-    @with_cache(ttl_seconds=3600)
-    async def get_coingecko_id(self, token_name):
-        try:
-            # Use CoinGecko's search API instead of coins/list
-            response = requests.get(
-                f"{self.api_url}/search?query={token_name}",
-                headers=self.headers
-            )
-            response.raise_for_status()
-            search_results = response.json()
-            print(f"search_results: {search_results}")
-            # Get the first coin result if available
-            if search_results.get('coins') and len(search_results['coins']) > 0:
-                return search_results['coins'][0]['id']
-            return None
-            
-        except requests.RequestException as e:
-            print(f"error: {e}")
-            return {"error": f"Failed to search for token: {str(e)}"}
+    # ------------------------------------------------------------------------
+    #                      COMMON HANDLER LOGIC
+    # ------------------------------------------------------------------------
+    async def _handle_tool_logic(
+        self, tool_name: str, function_args: dict, query: str, tool_call_id: str, raw_data_only: bool
+    ) -> Dict[str, Any]:
+        """
+        A single method that calls the appropriate function, handles
+        errors/formatting, and optionally calls the LLM to explain the result.
+        """
+        # Decide on temperature defaults per tool:
+        # (You could also store these in a dictionary if you want more variation)
+        temp_for_explanation = 0.7 if tool_name != 'get_trending_coins' else 0.3
 
-    @with_cache(ttl_seconds=3600)
-    async def get_token_info(self, coingecko_id):
-        try:
-            response = requests.get(f"{self.api_url}/coins/{coingecko_id}", headers=self.headers)
-            response.raise_for_status()
-            print(f"response: {response}")
-            return response.json()
-        except requests.RequestException as e:
-            print(f"error: {e}")
-            return {"error": f"Failed to fetch token info: {str(e)}"}
+        if tool_name == 'get_trending_coins':
+            result = await self.get_trending_coins()
+            errors = self._handle_error(result)
+            if errors:
+                return errors
+
+            if raw_data_only:
+                return {"response": "", "data": result}
+
+            explanation = await self._respond_with_llm(
+                query=query,
+                tool_call_id=tool_call_id,
+                data=result,
+                temperature=temp_for_explanation
+            )
+            return {"response": explanation, "data": result}
+
+        elif tool_name == 'get_coingecko_id':
+            token_name = function_args.get('token_name')
+            if not token_name:
+                return {"error": "Missing 'token_name' in tool_arguments"}
+            
+            raw_id_result = await self.get_coingecko_id(token_name)
+            if isinstance(raw_id_result, dict) and 'error' in raw_id_result:
+                return raw_id_result
+
+            # raw_id_result is presumably just the string id
+            coingecko_id = raw_id_result
+            # Optionally, also fetch token info or just return the ID:
+            # We'll just return the ID here:
+            final_data = {"coingecko_id": coingecko_id}
+            
+            if raw_data_only:
+                return {"response": "", "data": final_data}
+
+            explanation = await self._respond_with_llm(
+                query=query,
+                tool_call_id=tool_call_id,
+                data=final_data,
+                temperature=temp_for_explanation
+            )
+            return {"response": explanation, "data": final_data}
+
+        elif tool_name == 'get_token_info':
+            coingecko_id = function_args.get('coingecko_id')
+            if not coingecko_id:
+                return {"error": "Missing 'coingecko_id' in tool_arguments"}
+            
+            token_info = await self.get_token_info(coingecko_id)
+            errors = self._handle_error(token_info)
+            if errors:
+                return errors
+
+            formatted_data = self.format_token_info(token_info)
+            
+            if raw_data_only:
+                return {"response": "", "data": formatted_data}
+
+            explanation = await self._respond_with_llm(
+                query=query,
+                tool_call_id=tool_call_id,
+                data=formatted_data,
+                temperature=temp_for_explanation
+            )
+            return {"response": explanation, "data": formatted_data}
+
+        return {"error": f"Unsupported tool '{tool_name}'"}
+
+    @monitor_execution()
+    @with_retry(max_retries=3)
+    async def handle_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Either 'query' or 'tool' is required in params.
+          - If 'tool' is provided, call that tool directly with 'tool_arguments' (bypassing the LLM).
+          - If 'query' is provided, route via LLM for dynamic tool selection.
+        """
+        query = params.get('query')
+        tool_name = params.get('tool')
+        tool_args = params.get('tool_arguments', {})
+        raw_data_only = params.get('raw_data_only', False)
+
+        # ---------------------
+        # 1) DIRECT TOOL CALL
+        # ---------------------
+        if tool_name:
+            # For a direct tool call, we do NOT use call_llm_with_tools_async
+            # We simply call our helper. We'll pass an empty `query` or something placeholder
+            # if user hasn't given a `query`.
+            # We'll also pass tool_call_id = "direct_tool" for consistency.
+            return await self._handle_tool_logic(
+                tool_name=tool_name,
+                function_args=tool_args,
+                query=query or "Direct tool call without LLM.",
+                tool_call_id="direct_tool",
+                raw_data_only=raw_data_only
+            )
+
+        # ---------------------
+        # 2) NATURAL LANGUAGE QUERY (LLM decides the tool)
+        # ---------------------
+        if query:
+            response = await call_llm_with_tools_async(
+                base_url=self.heurist_base_url,
+                api_key=self.heurist_api_key,
+                model_id=self.metadata['large_model_id'],
+                system_prompt=self.get_system_prompt(),
+                user_prompt=query,
+                temperature=0.1,
+                tools=self.get_tool_schemas()
+            )
+            
+            if not response:
+                return {"error": "Failed to process query"}
+            if not response.get('tool_calls'):
+                # No tool calls => the LLM just answered
+                return {"response": response['content'], "data": {}}
+
+            # LLM provided a single tool call (or the first if multiple).
+            tool_call = response['tool_calls']
+            tool_call_name = tool_call.function.name
+            tool_call_args = json.loads(tool_call.function.arguments)
+
+            # Use the same _handle_tool_logic
+            return await self._handle_tool_logic(
+                tool_name=tool_call_name,
+                function_args=tool_call_args,
+                query=query,
+                tool_call_id=tool_call.id,
+                raw_data_only=raw_data_only
+            )
+
+        # ---------------------
+        # 3) NEITHER query NOR tool
+        # ---------------------
+        return {"error": "Either 'query' or 'tool' must be provided in the parameters."}

--- a/mesh_manager.py
+++ b/mesh_manager.py
@@ -66,19 +66,40 @@ class AgentLoader:
         }
 
         for agent_id, agent_cls in agents_dict.items():
+            logger.info(f"Creating metadata for agent {agent_id}")
             agent = agent_cls()
+            
+            # Get base inputs from agent metadata
+            inputs = agent.metadata.get('inputs', [])
 
-            # Safely call get_tool_schemas if it exists
-            tools = None
+            # Add tool-related inputs if tools exist
             if hasattr(agent, "get_tool_schemas") and callable(agent.get_tool_schemas):
                 tools = agent.get_tool_schemas()
+                if tools:
+                    inputs.extend([
+                        {
+                            'name': 'tool',
+                            'description': f'Directly specify which tool to call: {", ".join(t["function"]["name"] for t in tools)}. Bypasses LLM.',
+                            'type': 'str',
+                            'required': False
+                        },
+                        {
+                            'name': 'tool_arguments',
+                            'description': 'Arguments for the tool call as a dictionary',
+                            'type': 'dict',
+                            'required': False,
+                            'default': {}
+                        }
+                    ])
+                    # Update agent metadata with tool-derived inputs
+                    agent.metadata['inputs'] = inputs
 
-            # Compose agent info
-            metadata["agents"][agent_id] = {
-                "metadata": agent.metadata,
-                "module": agent_cls.__module__.split('.')[-1],
-                "tools": tools  # <-- Store the agent's tools here
-            }
+                    # Compose agent info
+                    metadata["agents"][agent_id] = {
+                        "metadata": agent.metadata,
+                        "module": agent_cls.__module__.split('.')[-1],
+                        "tools": tools
+                    }
 
         return metadata
     

--- a/mesh_manager.py
+++ b/mesh_manager.py
@@ -64,14 +64,22 @@ class AgentLoader:
             "last_updated": datetime.now(UTC).isoformat(),
             "agents": {}
         }
-        
+
         for agent_id, agent_cls in agents_dict.items():
             agent = agent_cls()
+
+            # Safely call get_tool_schemas if it exists
+            tools = None
+            if hasattr(agent, "get_tool_schemas") and callable(agent.get_tool_schemas):
+                tools = agent.get_tool_schemas()
+
+            # Compose agent info
             metadata["agents"][agent_id] = {
                 "metadata": agent.metadata,
-                "module": agent_cls.__module__.split('.')[-1]
+                "module": agent_cls.__module__.split('.')[-1],
+                "tools": tools  # <-- Store the agent's tools here
             }
-        
+
         return metadata
     
     def _upload_metadata(self, metadata: Dict) -> None:


### PR DESCRIPTION
- for certain agents, users can call with `tool` and `tool_arguments` to use the tool directly, without the first pass of LLM selecting the tool. 
- `/agents` endpoint and the uploaded metadata contain tool info
- refactor `handle_message` to handle direct tool use

Metadata json is like this: https://mesh.heurist.ai/mesh_agents_metadata.json