### PR TITLE
Fixed fix for tool decorator

### DIFF
--- a/agents/tool_decorator.py
+++ b/agents/tool_decorator.py
@@ -11,8 +11,9 @@ def tool(description: str):
         func.name = func.__name__
         func.description = func.__doc__ if func.__doc__ != inspect._empty else description
 
-        # Generate the parameter schema from the original function
+        # generate the parameter schema without agent_context
         signature = inspect.signature(func)
+        parameters = {k: v for k, v in signature.parameters.items() if k != "agent_context"}
         func.args_schema = {
             "type": "object",
             "properties": {
@@ -20,19 +21,18 @@ def tool(description: str):
                     "type": str(param_type.annotation.__name__).lower(),
                     "description": str(param_type.annotation) if param_type.annotation != inspect._empty else "No type specified"
                 }
-                for param, param_type in signature.parameters.items()
+                for param, param_type in parameters.items()
             },
             "required": [
                 param
-                for param, param_type in signature.parameters.items()
+                for param, param_type in parameters.items()
                 if param_type.default == inspect._empty
             ]
         }
         
         async def wrapper(args: Dict[str, Any], agent_context: Any):
-            # Remove agent_context from args if it exists
-            if "agent_context" in args:
-                args["agent_context"] = agent_context   
+            # re-add agent context
+            args["agent_context"] = agent_context   
             result = await func(**args) if inspect.iscoroutinefunction(func) else func(**args)
             return result
             


### PR DESCRIPTION
# Pull Request Title

<!-- 
  Thank you for your contribution! 
  Please provide a clear and concise description of the changes made, 
  and ensure the checklist below is complete before submitting.
-->

Fixes the [fix](https://github.com/heurist-network/heurist-agent-framework/commit/ba9f9805fc191e54056317e5ab804270424e72fc) that I proposed earlier.

## Description
<!-- 
  Give a brief description of your changes and why they are necessary. 
  Include relevant details such as:
  - What does this PR do?
  - Which problem does it solve or which feature does it introduce? 
  - What’s the motivation/goal behind this?
-->

Problem: currently the LLM needs to generate a tool_call with agent_context = {} (empty) and the wrapper replaces it with the real agent_context. 

What the fixed fix does:  agent_context is injected until wrapper execution, if needed. This increases the reliability of tool calls, especially if handled by smaller models.

## Related Issues / Tickets
<!-- 
  If this PR closes one or more issues, reference them here. 
  For example: 
  - Fixes #123
  - Closes #456
-->

[Original fix](https://github.com/heurist-network/heurist-agent-framework/commit/ba9f9805fc191e54056317e5ab804270424e72fc) had to be reversed, not it was tested with more cases.

## How Has This Been Tested?
<!-- 
  Describe how you tested your changes (unit tests, integration tests, manual tests, etc.). 
  If you added or changed tests, mention how they verify your code.
-->

- image generation with ./main_telegram.py
- get_time function (has no args) with ./main_telegram.py
- ./mesh/tests/bitquery_sol_token_info_agent.py
- ./mesh/tests/coingecko_token_info_agent.py
- ./mesh/tests/duckduckgo_search_agent.py

## Checklist
<!-- 
  Please tick applicable items in the following checklist before merging your PR. 
  This helps maintain code quality and consistency across the repository.
-->

- [x] **Documentation**: I have updated or added documentation where needed (in code, README, or other docs).
- [x] **Tests**: 
  - [x] Added or updated tests to cover my changes. All tests pass locally on my machine.
  - [ ] I have added a test script in `mesh/tests/` that instantiates my mesh agent and calls its `handle_message` with example input.
  - [ ] No tests needed for this PR.
- [ ] **Metadata** (for Heurist Mesh Agents): I have filled out or updated the agent’s metadata (name, description, author, inputs/outputs, etc.) if relevant.
- [x] **No Duplicates**: I have checked that no other PR is addressing the same issue or feature.
- [x] **No Breaking Changes**: The changes in this PR do not break existing functionality. If they do, I have clearly explained the impact below.

## Additional Notes
<!-- 
  Add any additional comments, references, or screenshots here. 
  If your change has significant design implications or requires special instructions, 
  please include those details.
-->

Sorry about the last one 😳

