### PR TITLE
simple price api replacing comparison tool

### DIFF
--- a/mesh/tests/coingecko_token_info_agent.py
+++ b/mesh/tests/coingecko_token_info_agent.py
@@ -39,9 +39,24 @@ async def run_agent():
         agent_output_direct = await agent.handle_message(agent_input_direct)
         print(f"Result of direct tool call: {agent_output_direct}")
 
+        # Test the new get_token_price_multi tool
+        agent_input_price_multi = {
+            "tool": "get_token_price_multi",
+            "tool_arguments": {
+                "ids": "bitcoin,ethereum,solana",
+                "vs_currencies": "usd",
+                "include_market_cap": True,
+                "include_24hr_vol": True,
+                "include_24hr_change": True,
+            },
+        }
+        agent_output_price_multi = await agent.handle_message(agent_input_price_multi)
+        print(f"Result of get_token_price_multi tool call: {agent_output_price_multi}")
+
+        # Test query for comparing multiple tokens
         agent_input_compare = {"query": "Compare Bitcoin and Ethereum"}
         agent_output_compare = await agent.handle_message(agent_input_compare)
-        print(f"Result of token comparison: {agent_output_compare}")
+        print(f"Result of token comparison query: {agent_output_compare}")
 
         script_dir = Path(__file__).parent
         current_file = Path(__file__).stem
@@ -57,6 +72,8 @@ async def run_agent():
             "output_by_trending": agent_output_trending,
             "input_direct_tool": agent_input_direct,
             "output_direct_tool": agent_output_direct,
+            "input_price_multi": agent_input_price_multi,
+            "output_price_multi": agent_output_price_multi,
             "input_comparison": agent_input_compare,
             "output_comparison": agent_output_compare,
         }

--- a/mesh/tests/coingecko_token_info_agent_example.yaml
+++ b/mesh/tests/coingecko_token_info_agent_example.yaml
@@ -1,60 +1,45 @@
 input_by_id:
   query: Get information about MONA
 output_by_id:
-  response: '### Monavale (MONA) Insights
-
-    - **Current Price:** $24.83
-
-    - **Market Cap:** $261,212
-
-    - **Market Cap Rank:** 5014
-
-    - **24h Trading Volume:** $514.87
-
-    - **24h High:** $25.01
-
-    - **24h Low:** $23.96
-
-    - **Price Change (24h):** +$0.34 (+1.39%)
-
-    - **Circulating Supply:** 10,456.13 MONA
-
-    - **Total Supply:** 11,300 MONA
-
-    - **Max Supply:** 11,300 MONA
-
-
-    Monavale is currently valued at $24.83, with a modest market cap of approximately
-    $261K. It has experienced a 24-hour price increase of 1.39%, reflecting some market
-    interest.'
+  response: "**Monavale (MONA)**\n- **Current Price:** $25.35\n- **Market Cap:** $263,449\n\
+    - **Market Cap Rank:** 5027\n- **Total Volume (24h):** $281.53\n- **24h High/Low:**\
+    \ $25.35 / $24.39\n- **Price Change (24h):** +$0.88 (3.60%)\n- **Circulating Supply:**\
+    \ 10,456.13 MONA\n- **Total Supply:** 11,300 MONA\n- **Max Supply:** 11,300 MONA\
+    \ \n\nMonavale has shown a positive price movement in the last 24 hours with a\
+    \ notable increase of 3.60%. Despite its lower market cap rank, it has a defined\
+    \ total and circulating supply which could be important for future evaluations."
   data: {}
 input_by_name:
   query: analyze HEU
 output_by_name:
-  response: "### Heurist (HEU) Overview:\n- **Current Price**: $0.0162\n- **Market\
-    \ Cap**: $1.9M\n- **Market Cap Rank**: 2772\n- **24h Trading Volume**: $68.7K\n\
-    - **High (24h)**: $0.0162\n- **Low (24h)**: $0.0150\n- **Price Change (24h)**:\
-    \ +$0.0011 (+7.03%)\n- **Circulating Supply**: 117,031,319 HEU\n- **Total Supply**:\
-    \ 1,000,000,000 HEU\n- **Max Supply**: 1,000,000,000 HEU  \n\n### Key Insights:\n\
-    - Heurist has experienced a notable price increase of 7.03% in the last 24 hours.\n\
-    - The market cap rank is low (2772), indicating it may be a less known or emerging\
-    \ token.\n- The trading volume suggests a moderate level of activity in the market."
+  response: "**Heurist (HEU)**\n- **Current Price:** $0.0162\n- **Market Cap:** $1.9M\
+    \  \n- **Market Cap Rank:** 2774\n- **24h Trading Volume:** $71.4K  \n- **24h\
+    \ High/Low:** $0.0165 / $0.0153\n- **Price Change (24h):** +$0.00066 (+4.24%)\n\
+    - **Circulating Supply:** 117.0M HEU\n- **Total Supply:** 1.0B HEU\n\n**Insights:**\
+    \ Heurist is currently trading with a low market cap and has seen a moderate price\
+    \ increase in the last 24 hours. With its circulating supply being a significant\
+    \ portion of its total supply, any future price movements could be influenced\
+    \ by market demand."
   data: {}
 input_by_trending:
   query: Get information about trending coins
 output_by_trending:
-  response: "Here are the current top trending cryptocurrencies:\n\n1. **Bitcoin (BTC)**\n\
-    \   - **Market Cap Rank**: 1\n   - **Price**: $83,616.36\n\n2. **Ethereum (ETH)**\n\
-    \   - **Market Cap Rank**: 2\n   - **Price**: $2,001.82\n\n3. **Solana (SOL)**\n\
-    \   - **Market Cap Rank**: 6\n   - **Price**: $127.23\n\n4. **Hyperliquid (HYPE)**\n\
-    \   - **Market Cap Rank**: 32\n   - **Price**: $14.84\n\n5. **MANTRA (OM)**\n\
-    \   - **Market Cap Rank**: 26\n   - **Price**: $6.90\n\n6. **Pi Network (PI)**\n\
-    \   - **Market Cap Rank**: 21\n   - **Price**: $1.15\n\n7. **Sonic (S)** (previously\
-    \ FTM)\n   - **Market Cap Rank**: 66\n   - **Price**: $0.52\n\n8. **Ondo (ONDO)**\n\
-    \   - **Market Cap Rank**: 47\n   - **Price**: $0.85\n\n9. **Plume (PLUME)**\n\
-    \   - **Market Cap Rank**: 167\n   - **Price**: $0.20\n\n10. **Epic Chain (EPIC)**\n\
-    \    - **Market Cap Rank**: 923\n    - **Price**: $1.37 \n\nThese coins are currently\
-    \ showing significant interest and activity in the market."
+  response: "### Trending Coins Insights\nHere are the current trending cryptocurrencies\
+    \ along with their market cap ranks and prices:\n\n1. **Bitcoin (BTC)**  \n  \
+    \ - **Market Cap Rank:** 1  \n   - **Price:** $85,897.48  \n\n2. **Ethereum (ETH)**\
+    \  \n   - **Market Cap Rank:** 2  \n   - **Price:** $2,013.77  \n\n3. **XRP (XRP)**\
+    \  \n   - **Market Cap Rank:** 4  \n   - **Price:** $2.45  \n\n4. **Pi Network\
+    \ (PI)**  \n   - **Market Cap Rank:** 21  \n   - **Price:** $1.18  \n\n5. **Sui\
+    \ (SUI)**  \n   - **Market Cap Rank:** 22  \n   - **Price:** $2.43  \n\n6. **Ondo\
+    \ (ONDO)**  \n   - **Market Cap Rank:** 48  \n   - **Price:** $0.87  \n\n7. **PancakeSwap\
+    \ (CAKE)**  \n   - **Market Cap Rank:** 109  \n   - **Price:** $2.54  \n\n8. **Plume\
+    \ (PLUME)**  \n   - **Market Cap Rank:** 154  \n   - **Price:** $0.22  \n\n9.\
+    \ **Tutorial (TUT)**  \n   - **Market Cap Rank:** 643  \n   - **Price:** $0.05\
+    \  \n\n10. **Koma Inu (KOMA)**  \n    - **Market Cap Rank:** 958  \n    - **Price:**\
+    \ $0.04  \n\n### Summary\nBitcoin and Ethereum remain dominant in the market,\
+    \ showcasing their stability and continued interest from investors. Other coins\
+    \ like Pi Network and Sui are gaining attention, indicating potential growth areas\
+    \ in the market."
   data: {}
 input_direct_tool:
   tool: get_token_info
@@ -69,55 +54,94 @@ output_direct_tool:
       name: Bitcoin
       symbol: BTC
       market_cap_rank: 1
-      current_price: 83686
-      market_cap: 1663866425863
-      total_volume: 24353719925
-      high_24h: 84010
-      low_24h: 81208
-      price_change_24h: 1301
-      price_change_percentage_24h: 1.57918
-      circulating_supply: 19838918.0
-      total_supply: 19838918.0
+      current_price: 85845
+      market_cap: 1702696269673
+      total_volume: 38694633327
+      high_24h: 87431
+      low_24h: 83176
+      price_change_24h: 2532
+      price_change_percentage_24h: 3.03955
+      circulating_supply: 19839309.0
+      total_supply: 19839337.0
       max_supply: 21000000.0
+input_price_multi:
+  tool: get_token_price_multi
+  tool_arguments:
+    ids: bitcoin,ethereum,solana
+    vs_currencies: usd
+    include_market_cap: true
+    include_24hr_vol: true
+    include_24hr_change: true
+output_price_multi:
+  response: ''
+  data:
+    price_data:
+      bitcoin:
+        usd: 85839
+        usd_market_cap: 1702696269673.3582
+        usd_24h_vol: 38646179297.04689
+        usd_24h_change: 3.0323614891835136
+      ethereum:
+        usd: 2011.63
+        usd_market_cap: 243518829179.4357
+        usd_24h_vol: 21297943766.31841
+        usd_24h_change: 3.7109333094668564
+      solana:
+        usd: 134.42
+        usd_market_cap: 68289937842.27508
+        usd_24h_vol: 4290256382.080711
+        usd_24h_change: 6.336729156910368
 input_comparison:
   query: Compare Bitcoin and Ethereum
 output_comparison:
-  response: 'It appears the agent got rate-limited and failed to retrieve the full
-    comparison. I can still provide a comparison based on the data retrieved before
-    the error.
+  response: 'The agent encountered rate limiting issues and could only retrieve full
+    data for Bitcoin. However, here''s a comparison based on available information
+    and general knowledge:
 
 
-    **Bitcoin (BTC) vs. Ethereum (ETH): A Concise Comparison**
+    **Bitcoin (BTC):**
 
 
-    Here''s a comparison of Bitcoin and Ethereum based on the data obtained:
+    *   **Purpose:** Primarily designed as a decentralized digital currency and store
+    of value.
+
+    *   **Market Cap:** $1.7 Trillion (Rank 1)
+
+    *   **Price:** $85,845
+
+    *   **24h Volume:** $38.7 Billion
+
+    *   **Supply:** Limited to 21 million. Circulating supply is currently 19.84 million.
+
+    *   **Technology:** First generation blockchain; focuses on security and decentralization.
 
 
-    *   **Market Cap:** Bitcoin dominates with a market cap of $1.66T, significantly
-    higher than Ethereum''s $244.37B.
-
-    *   **Price:** Bitcoin is trading at $83,749, much higher than Ethereum''s $2,005.54.
-
-    *   **24h Price Change:** Ethereum shows a larger percentage increase in the last
-    24 hours (5.81%) compared to Bitcoin (1.66%).
-
-    *   **Total Supply:** Bitcoin has a capped max supply of 21 million, promoting
-    scarcity. Ethereum has no max supply.
-
-    *   **Market Cap Rank:** Bitcoin is the #1 cryptocurrency, while Ethereum is #2.
-
-    *   **Circulating Supply:** Bitcoin''s circulating supply is 19.84 million. Ethereum''s
-    is 120.63 million.
+    **Ethereum (ETH):**
 
 
-    **Key Insights:**
+    *   **Purpose:** A platform for decentralized applications (dApps) and smart contracts.
+    While also a cryptocurrency, its main strength lies in its utility.
+
+    *   **Technology:** Second generation blockchain; introduces smart contract functionality.
 
 
-    *   Bitcoin remains the dominant cryptocurrency by market capitalization and price.
+    **Key Differences and Insights (Based on general knowledge):**
 
-    *   Ethereum shows higher percentage growth in the last 24 hours, suggesting higher
-    volatility or recent positive market sentiment.
 
-    *   Bitcoin''s capped supply differentiates it from Ethereum, potentially affecting
-    its long-term value proposition.'
+    *   **Functionality:** Bitcoin''s primary use is as digital gold, while Ethereum
+    is a platform for a wide range of applications.
+
+    *   **Technology:** Bitcoin uses Proof-of-Work (PoW), consuming significant energy.
+    Ethereum has transitioned to Proof-of-Stake (PoS), which is more energy-efficient.
+
+    *   **Use Cases:** Bitcoin is largely for store of value and peer-to-peer payments.
+    Ethereum supports DeFi, NFTs, and other dApps.
+
+    *   **Supply:** While Bitcoin has a hard cap, Ethereum''s supply is not strictly
+    capped.
+
+
+    Unfortunately, due to API limitations, I can''t provide current price and market
+    cap data for Ethereum at this time. However, the high-level comparison above should
+    be helpful.'
   data: {}


### PR DESCRIPTION
This pull request have a new simple price API replacing comparison tool,
Allowing to fetch details for coins 
Parameters:
ID (chain ID or coin id)
vs_currencies (Coin id or currency which can be used to compare vs ID)
also can include

include_market_cap
boolean
include market capitalization, default: false

include_24hr_vol
boolean
include 24hr volume, default: false

include_24hr_change
boolean
include 24hr change, default: false

include_last_updated_at
boolean
include last updated price time in UNIX, default: false

precision
string
decimal place for currency price value