### PR TITLE
ci(docker): init config for docker swarm and 0 downtime

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -28,8 +28,8 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
-startsecs=5
-stopwaitsecs=10
+startsecs=2
+stopwaitsecs=5
 priority=20
 
 [program:mesh_manager]
@@ -41,6 +41,6 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
-startsecs=5
-stopwaitsecs=10
+startsecs=2
+stopwaitsecs=5
 priority=10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,11 +64,11 @@ jobs:
 
       - name: Wait for deployment
         run: |
-          echo "Waiting 10 seconds for deployment to start..."
-          sleep 10
+          echo "Waiting 45 seconds for deployment to start..."
+          sleep 45
 
-          for i in {1..30}; do
-            echo "Waiting for deployment... (attempt $i/30)"
+          for i in {1..45}; do
+            echo "Waiting for deployment... (attempt $i/45)"
             response=$(curl -s https://sequencer-v2.heurist.xyz/mesh_health || echo "")
 
             commit=$(echo "$response" | jq -r '.commit' 2>/dev/null || echo "")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@ services:
       update_config:
         order: start-first
         failure_action: rollback
-        delay: 10s
+        delay: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   mesh:
-    container_name: mesh-backend
     image: ghcr.io/heurist-network/heurist-agent-framework/mesh:${COMMIT_SHA:-latest}
     build:
       context: .
@@ -12,7 +11,13 @@ services:
       - .env
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/mesh_health"]
-      interval: 30s
-      timeout: 10s
+      interval: 10s
+      timeout: 5s
       retries: 3
-      start_period: 5s
+      start_period: 2s
+    deploy:
+      replicas: 2
+      update_config:
+        order: start-first
+        failure_action: rollback
+        delay: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8000/mesh_health"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 2s
+      retries: 5
+      start_period: 5s
     deploy:
       replicas: 2
       update_config:


### PR DESCRIPTION
right now, after a change is deployed, the action runs, which sends a request to the webhook to run `docker-compose up`. this results in a few seconds of downtime as the new process starts.

- [ ] init docker swarm on prod machine
- [ ] switch out webhook on prod machine to support swarm confing
- [ ] test thoroughly