### PR TITLE
feat: add Tavily search provider to core SearchClient factory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,7 @@ ELFA_API_KEY=your_elfa_api_key                     # for ElfaTwitterIntelligence
 BITQUERY_API_KEY=your_bitquery_api_key             # for PumpFunTokenAgent
 COINGECKO_API_KEY=your_coingecko_api_key           # for CoinGeckoTokenInfoAgent
 EXA_API_KEY=your_exa_api_key                       # for ExaSearchAgent
+TAVILY_API_KEY=your_tavily_api_key                 # for Tavily search client
 CARV_API_KEY=your_carv_api_key                     # for CarvOnchainDataAgent
 HELIUS_API_KEY=your_helius_api_key                 # for SolWalletAgent
 MONI_API_KEY=your_moni_api_key                     # for MoniTwitterInsightAgent

--- a/core/clients/search/tavily_client.py
+++ b/core/clients/search/tavily_client.py
@@ -1,0 +1,39 @@
+import asyncio
+from typing import Optional
+
+from tavily import TavilyClient as TavilySDKClient
+
+from .base_search_client import BaseSearchClient, SearchResponse
+
+
+class TavilyClient(BaseSearchClient):
+    """Tavily implementation of the search client."""
+
+    def __init__(self, api_key: str = "", api_url: Optional[str] = None, rate_limit: int = 1):
+        super().__init__(api_key, api_url, rate_limit)
+        self.client = TavilySDKClient(api_key=api_key)
+
+    async def search(self, query: str, timeout: int = 15000) -> SearchResponse:
+        """Search using Tavily API."""
+        try:
+            await self._apply_rate_limiting()
+
+            response = await asyncio.get_event_loop().run_in_executor(
+                None, lambda: self.client.search(query=query, max_results=10, search_depth="basic")
+            )
+
+            formatted_results = []
+            for result in response.get("results", []):
+                formatted_results.append(
+                    {
+                        "url": result.get("url", ""),
+                        "markdown": result.get("content", ""),
+                        "title": result.get("title", ""),
+                    }
+                )
+
+            return {"data": formatted_results}
+
+        except Exception as e:
+            print(f"Error searching with Tavily: {e}")
+            return {"data": []}

--- a/core/clients/search_client.py
+++ b/core/clients/search_client.py
@@ -4,6 +4,7 @@ from .search.base_search_client import BaseSearchClient, SearchResponse
 from .search.duckduckgo_client import DuckDuckGoClient
 from .search.exa_client import ExaClient
 from .search.firecrawl_client import FirecrawlClient
+from .search.tavily_client import TavilyClient
 
 
 class SearchClient(BaseSearchClient):
@@ -32,6 +33,8 @@ class SearchClient(BaseSearchClient):
         elif client_type.lower() == "duckduckgo":
             # DuckDuckGo doesn't require API key or custom URL
             self._implementation = DuckDuckGoClient(rate_limit=rate_limit)
+        elif client_type.lower() == "tavily":
+            self._implementation = TavilyClient(api_key=api_key, api_url=api_url, rate_limit=rate_limit)
         else:
             raise ValueError(f"Unsupported search client type: {client_type}")
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "aiohttp==3.11.15",
     "mcp==1.6.0",
     "firecrawl-py==2.8.0",
+    "tavily-python>=0.5.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "duckduckgo-search==7.4.3", # ddg agent
     "fastapi==0.115.12", # for mesh api server
     "firecrawl-py==2.8.0", # firecrawl agent
+    "tavily-python>=0.5.0", # tavily search client
     "flask==3.1.0",
     "flask[async]==3.1.0",
     "loguru==0.7.3",


### PR DESCRIPTION
## Summary
- Added Tavily as a fourth named search provider alongside Exa, DuckDuckGo, and Firecrawl in the unified `SearchClient` factory
- Created `TavilyClient` class implementing `BaseSearchClient` interface using the `tavily-python` SDK
- This is an additive change — existing providers are untouched

## Files changed
- `core/clients/search/tavily_client.py` — **new file**: `TavilyClient` wrapping `tavily-python` SDK, conforming to `BaseSearchClient` (search method returns `SearchResponse` with url/markdown/title fields)
- `core/clients/search_client.py` — added `'tavily'` branch to factory `__init__` and imported `TavilyClient`
- `.env.example` — added `TAVILY_API_KEY` entry
- `pyproject.toml` — added `tavily-python>=0.5.0` dependency
- `core/pyproject.toml` — added `tavily-python>=0.5.0` dependency

## Dependency changes
- Added `tavily-python>=0.5.0` to root `pyproject.toml`
- Added `tavily-python>=0.5.0` to `core/pyproject.toml`

## Environment variable changes
- Added `TAVILY_API_KEY` (required when using `client_type='tavily'`)

## Notes for reviewers
- The `TavilyClient` follows the same pattern as `ExaClient`: rate limiting, sync SDK call in executor, formatted results with url/markdown/title keys
- Uses `search_depth="basic"` (1 credit) by default; can be changed to `"advanced"` (2 credits) for higher relevance
- Maps Tavily's `content` field to `markdown` to match the existing response format convention


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily client implementation is correct, well-scoped, and consistent with the existing codebase patterns. All five files from the plan are addressed: the new TavilyClient class, factory registration, env var documentation, and both pyproject.toml dependency updates. No regressions or critical issues found.
