### PR TITLE
feat: add Tavily as fallback search provider for DuckDuckGo

### DIFF
--- a/core/clients/search/duckduckgo_client.py
+++ b/core/clients/search/duckduckgo_client.py
@@ -1,14 +1,19 @@
 import asyncio
+import logging
+import os
 
 from duckduckgo_search import DDGS
 
 from .base_search_client import BaseSearchClient, SearchResponse
+
+logger = logging.getLogger(__name__)
 
 
 class DuckDuckGoClient(BaseSearchClient):
     """
     DuckDuckGo implementation of the search client.
     DuckDuckGo is unique among search providers as it doesn't require an API key or custom URL.
+    Falls back to Tavily when TAVILY_API_KEY is set and DDGS fails.
     """
 
     def __init__(self, rate_limit: int = 1):
@@ -18,18 +23,20 @@ class DuckDuckGoClient(BaseSearchClient):
         Args:
             rate_limit: Rate limit in seconds between requests
         """
-        # We call the parent constructor with empty strings for api_key and api_url
-        # since DuckDuckGo doesn't use these parameters
         super().__init__(api_key="", api_url=None, rate_limit=rate_limit)
+        self.tavily_client = None
+        tavily_api_key = os.getenv("TAVILY_API_KEY")
+        if tavily_api_key:
+            from tavily import TavilyClient
+
+            self.tavily_client = TavilyClient(api_key=tavily_api_key)
+            logger.info("Tavily client initialized as fallback for DuckDuckGoClient")
 
     async def search(self, query: str, timeout: int = 15000) -> SearchResponse:
-        """Search using DuckDuckGo in a thread pool to keep it async."""
+        """Search using DuckDuckGo in a thread pool to keep it async, with Tavily fallback."""
         try:
-            # Apply rate limiting
             await self._apply_rate_limiting()
 
-            # Run the synchronous DDGS call in a thread pool
-            # Note: DDGS doesn't accept a timeout parameter for its text() method
             response = await asyncio.get_event_loop().run_in_executor(
                 None, lambda: self._perform_search(query, max_results=10)
             )
@@ -37,27 +44,39 @@ class DuckDuckGoClient(BaseSearchClient):
             return {"data": response}
 
         except Exception as e:
-            print(f"Error searching with DuckDuckGo: {e}")
+            logger.warning(f"DuckDuckGo search failed: {e}, attempting Tavily fallback")
+            if self.tavily_client:
+                return await self._tavily_fallback_search(query)
+            logger.error(f"Error searching with DuckDuckGo (no Tavily fallback available): {e}")
             return {"data": []}
 
     def _perform_search(self, query: str, max_results: int = 10) -> list:
-        """
-        Perform the actual search using DDGS.
-        Note: Unlike other search clients, DDGS doesn't accept a timeout parameter.
-        """
         results = []
-        try:
-            with DDGS() as ddgs:
-                # DDGS text() doesn't accept a timeout parameter
-                for r in ddgs.text(query, max_results=max_results):
-                    results.append(
-                        {
-                            "url": r["href"],
-                            "markdown": r["body"],
-                            "title": r["title"],
-                        }
-                    )
-        except Exception as e:
-            print(f"DDGS search error: {e}")
-
+        with DDGS() as ddgs:
+            for r in ddgs.text(query, max_results=max_results):
+                results.append(
+                    {
+                        "url": r["href"],
+                        "markdown": r["body"],
+                        "title": r["title"],
+                    }
+                )
         return results
+
+    async def _tavily_fallback_search(self, query: str, max_results: int = 10) -> SearchResponse:
+        def _do_tavily_search():
+            response = self.tavily_client.search(query=query, max_results=max_results)
+            results = []
+            for r in response.get("results", []):
+                results.append(
+                    {
+                        "url": r.get("url", ""),
+                        "markdown": r.get("content", ""),
+                        "title": r.get("title", ""),
+                    }
+                )
+            return results
+
+        results = await asyncio.get_event_loop().run_in_executor(None, _do_tavily_search)
+        logger.info(f"Tavily fallback returned {len(results)} results for: {query}")
+        return {"data": results}

--- a/mesh/agents/duckduckgo_search_agent.py
+++ b/mesh/agents/duckduckgo_search_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
@@ -15,6 +16,13 @@ load_dotenv()
 class DuckDuckGoSearchAgent(MeshAgent):
     def __init__(self):
         super().__init__()
+        self.tavily_client = None
+        tavily_api_key = os.getenv("TAVILY_API_KEY")
+        if tavily_api_key:
+            from tavily import TavilyClient
+
+            self.tavily_client = TavilyClient(api_key=tavily_api_key)
+            logger.info("Tavily client initialized as fallback for DuckDuckGo")
         self.metadata.update(
             {
                 "name": "DuckDuckGo Agent",
@@ -77,7 +85,7 @@ class DuckDuckGoSearchAgent(MeshAgent):
     @with_cache(ttl_seconds=300)
     @with_retry(max_retries=3)
     async def search_web(self, search_term: str, max_results: int = 5) -> Dict:
-        """Search the web using DuckDuckGo"""
+        """Search the web using DuckDuckGo, with Tavily fallback on failure"""
         logger.info(f"Searching web for: {search_term}, max_results: {max_results}")
         try:
 
@@ -94,8 +102,25 @@ class DuckDuckGoSearchAgent(MeshAgent):
             return {"status": "success", "data": {"search_term": search_term, "results": results}}
 
         except Exception as e:
-            logger.error(f"Search error: {str(e)}")
+            logger.warning(f"DuckDuckGo search failed: {str(e)}, attempting Tavily fallback")
+            if self.tavily_client:
+                return await self._tavily_fallback_search(search_term, max_results)
+            logger.error(f"Search error (no Tavily fallback available): {str(e)}")
             return {"status": "error", "error": f"Failed to fetch search results: {str(e)}", "data": None}
+
+    async def _tavily_fallback_search(self, search_term: str, max_results: int = 5) -> Dict:
+        """Fallback search using Tavily when DuckDuckGo fails"""
+
+        def _do_tavily_search():
+            response = self.tavily_client.search(query=search_term, max_results=max_results)
+            results = []
+            for r in response.get("results", []):
+                results.append({"title": r.get("title", ""), "link": r.get("url", ""), "snippet": r.get("content", "")})
+            return results
+
+        results = await asyncio.get_event_loop().run_in_executor(None, _do_tavily_search)
+        logger.info(f"Tavily fallback returned {len(results)} results for: {search_term}")
+        return {"status": "success", "data": {"search_term": search_term, "results": results}}
 
     # ------------------------------------------------------------------------
     #                      TOOL HANDLING LOGIC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "boto3==1.37.18", # utils/crypto/crypto_nft.py
     "botocore==1.37.18", # utils/crypto/crypto_nft.py
     "duckduckgo-search==7.4.3", # ddg agent
+    "tavily-python>=0.5.0", # tavily fallback for ddg agent
     "fastapi==0.115.12", # for mesh api server
     "firecrawl-py==2.8.0", # firecrawl agent
     "flask==3.1.0",


### PR DESCRIPTION
## Summary

- Added Tavily as an optional fallback when DuckDuckGo searches fail (rate limits, connectivity errors)
- Both `mesh/agents/duckduckgo_search_agent.py` and `core/clients/search/duckduckgo_client.py` now initialize a `TavilyClient` when `TAVILY_API_KEY` is present
- On DuckDuckGo failure, searches automatically fall back to Tavily and return results in the same format
- Fallback is gated by the presence of `TAVILY_API_KEY` — no behavior change if the env var is not set

## Files changed

- `mesh/agents/duckduckgo_search_agent.py` — Added Tavily client init and `_tavily_fallback_search()` method
- `core/clients/search/duckduckgo_client.py` — Added Tavily client init and `_tavily_fallback_search()` method; let DDGS exceptions propagate to trigger fallback
- `pyproject.toml` — Added `tavily-python>=0.5.0` dependency

## Dependency changes

- Added `tavily-python>=0.5.0` to `pyproject.toml`

## Environment variable changes

- `TAVILY_API_KEY` — optional; enables Tavily fallback when set

## Notes for reviewers

- This is an additive change; DuckDuckGo remains the primary search provider
- Tavily fallback only activates on DuckDuckGo failure AND when `TAVILY_API_KEY` is configured
- Result format is preserved (same keys/structure) regardless of which provider responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The implementation correctly adds Tavily as an opt-in fallback for DuckDuckGo in both the mesh agent and the core client. The fallback pattern is sound: TavilyClient (sync) is properly wrapped in `run_in_executor`, result shapes match what callers expect, and the dependency is added to `pyproject.toml`. The prerequisite units (tavily-core-client, tavily-mesh-agent) cover `core/pyproject.toml`, `.env.example`, and the Tavily SDK wiring, so their absence here is appropriate. No regressions or broken imports were found. One minor issue exists around `asyncio.get_event_loop()` deprecation, but this is pre-existing throughout the codebase and not introduced by this PR.
