### PR TITLE
feat(llm): add LiteLLM AI gateway as a backend for LLMProvider

### DIFF
--- a/core/components/llm_provider.py
+++ b/core/components/llm_provider.py
@@ -5,9 +5,23 @@ import os
 from typing import Dict, List, Optional, Tuple
 
 # Import your LLM functions
-from ..llm import LLMError, call_llm, call_llm_with_tools
+from ..llm import (
+    LLMError,
+    call_llm,
+    call_llm_litellm,
+    call_llm_with_tools,
+    call_llm_with_tools_litellm,
+)
 
 logger = logging.getLogger(__name__)
+
+# Provider backends. "heurist" routes through the OpenAI client + Heurist
+# gateway base_url (default, original behavior). "litellm" routes through the
+# embedded LiteLLM SDK so a single provider can talk to 100+ hosted backends
+# (OpenAI, Anthropic, Vertex AI, Bedrock, Azure, Groq, Mistral, ...) without a
+# separate proxy server. Pick the backend with `provider=` on __init__.
+HEURIST_BACKEND = "heurist"
+LITELLM_BACKEND = "litellm"
 
 
 class LLMProvider:
@@ -20,12 +34,27 @@ class LLMProvider:
         large_model_id: str = None,
         small_model_id: str = None,
         tool_manager=None,
+        provider: str = HEURIST_BACKEND,
+        litellm_kwargs: Dict = None,
     ):
-        self.base_url = base_url or os.getenv("HEURIST_BASE_URL")
-        self.api_key = api_key or os.getenv("HEURIST_API_KEY")
+        self.provider = provider
         self.large_model_id = large_model_id or os.getenv("LARGE_MODEL_ID")
         self.small_model_id = small_model_id or os.getenv("SMALL_MODEL_ID")
         self.tool_manager = tool_manager
+        self.litellm_kwargs = litellm_kwargs
+
+        if provider == LITELLM_BACKEND:
+            # LiteLLM resolves provider keys from per-provider env vars
+            # (ANTHROPIC_API_KEY, OPENAI_API_KEY, AWS_*, ...) when api_key is
+            # unset. base_url is used only for OpenAI-compatible custom
+            # endpoints (e.g., a private LiteLLM proxy or Foundry deployment).
+            self.base_url = base_url
+            self.api_key = api_key
+        elif provider == HEURIST_BACKEND:
+            self.base_url = base_url or os.getenv("HEURIST_BASE_URL")
+            self.api_key = api_key or os.getenv("HEURIST_API_KEY")
+        else:
+            raise ValueError(f"Unknown LLM provider backend: {provider}")
 
     async def call(
         self,
@@ -43,9 +72,11 @@ class LLMProvider:
         try:
             # Determine which model to use
             use_model = model_id or self.large_model_id
-            if not skip_tools and tools:
+            with_tools = (not skip_tools) and tools
+            tools_fn, no_tools_fn, extra = self._dispatch()
+            if with_tools:
                 response = await asyncio.to_thread(
-                    call_llm_with_tools,
+                    tools_fn,
                     base_url=self.base_url,
                     api_key=self.api_key,
                     model_id=use_model,
@@ -55,10 +86,11 @@ class LLMProvider:
                     max_tokens=max_tokens,
                     tools=tools,
                     tool_choice=tool_choice,
+                    **extra,
                 )
             else:
                 response = await asyncio.to_thread(
-                    call_llm,
+                    no_tools_fn,
                     base_url=self.base_url,
                     api_key=self.api_key,
                     model_id=use_model,
@@ -66,6 +98,7 @@ class LLMProvider:
                     user_prompt=user_prompt,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    **extra,
                 )
             # Process response
             text_response = ""
@@ -118,6 +151,13 @@ class LLMProvider:
         except Exception as e:
             logger.error(f"Unexpected error in LLM call: {str(e)}")
             return "Sorry, something went wrong.", None, None
+
+    def _dispatch(self):
+        """Pick the (tools_fn, no_tools_fn, extra_kwargs) trio for the active backend."""
+        if self.provider == LITELLM_BACKEND:
+            extra = {"litellm_kwargs": self.litellm_kwargs} if self.litellm_kwargs else {}
+            return call_llm_with_tools_litellm, call_llm_litellm, extra
+        return call_llm_with_tools, call_llm, {}
 
     def call_with_tools(
         self,

--- a/core/llm.py
+++ b/core/llm.py
@@ -185,6 +185,165 @@ async def call_llm_with_tools_async(
         raise LLMError(f"LLM API call failed: {str(e)}")
 
 
+# ---------------------------------------------------------------------------
+# LiteLLM gateway path
+#
+# Same call-site contract as call_llm / call_llm_with_tools but routes through
+# the LiteLLM SDK (`litellm.completion` / `litellm.acompletion`) so a single
+# LLMProvider can talk to OpenAI, Anthropic, Vertex AI, Bedrock, Azure, Groq,
+# Mistral, Ollama, and 90+ other backends. The model is selected via the
+# standard LiteLLM provider-prefixed name ("anthropic/claude-...", "azure/...",
+# "vertex_ai/...", etc.) and credentials are resolved either from the api_key
+# / base_url passed here or from provider-specific env vars (ANTHROPIC_API_KEY,
+# OPENAI_API_KEY, AWS_*, AZURE_*, ...).
+#
+# `drop_params=True` is enabled by default so kwargs that some providers reject
+# (frequency_penalty / presence_penalty on Anthropic, Gemini, Bedrock; etc.)
+# are silently dropped instead of raising UnsupportedParamsError.
+# ---------------------------------------------------------------------------
+
+
+def _litellm_kwargs(api_key, base_url, max_retries, extra):
+    kwargs = {"drop_params": True}
+    if max_retries is not None:
+        kwargs["num_retries"] = max_retries
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["api_base"] = base_url
+    if extra:
+        kwargs.update(extra)
+    return kwargs
+
+
+def call_llm_litellm(
+    base_url: str,
+    api_key: str,
+    model_id: str,
+    system_prompt: str = None,
+    user_prompt: str = None,
+    messages: List[Dict] = None,
+    temperature: float = 0.7,
+    max_tokens: int = 500,
+    max_retries: int = 3,
+    litellm_kwargs: Dict = None,
+):
+    import litellm
+
+    formatted_messages = _format_messages(system_prompt, user_prompt, messages)
+    kwargs = _litellm_kwargs(api_key, base_url, max_retries, litellm_kwargs)
+
+    try:
+        result = litellm.completion(
+            model=model_id,
+            messages=formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        return _handle_tool_response(result.choices[0].message)
+    except Exception as e:
+        raise LLMError(f"LiteLLM API call failed: {str(e)}")
+
+
+def call_llm_with_tools_litellm(
+    base_url: str,
+    api_key: str,
+    model_id: str,
+    system_prompt: str = None,
+    user_prompt: str = None,
+    messages: List[Dict] = None,
+    temperature: float = 0.7,
+    max_tokens: int = None,
+    max_retries: int = 3,
+    tools: List[Dict] = None,
+    tool_choice: str = "auto",
+    litellm_kwargs: Dict = None,
+) -> Union[str, Dict]:
+    import litellm
+
+    formatted_messages = _format_messages(system_prompt, user_prompt, messages)
+    kwargs = _litellm_kwargs(api_key, base_url, max_retries, litellm_kwargs)
+
+    try:
+        response = litellm.completion(
+            model=model_id,
+            messages=formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            tool_choice=tool_choice if tools else None,
+            **kwargs,
+        )
+        return _handle_tool_response(response.choices[0].message)
+    except Exception as e:
+        raise LLMError(f"LiteLLM API call failed: {str(e)}")
+
+
+async def call_llm_litellm_async(
+    base_url: str,
+    api_key: str,
+    model_id: str,
+    system_prompt: str = None,
+    user_prompt: str = None,
+    messages: List[Dict] = None,
+    temperature: float = 0.7,
+    max_tokens: int = 25000,
+    max_retries: int = 3,
+    litellm_kwargs: Dict = None,
+) -> str:
+    import litellm
+
+    formatted_messages = _format_messages(system_prompt, user_prompt, messages)
+    kwargs = _litellm_kwargs(api_key, base_url, max_retries, litellm_kwargs)
+
+    try:
+        result = await litellm.acompletion(
+            model=model_id,
+            messages=formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        return result.choices[0].message.content
+    except Exception as e:
+        raise LLMError(f"LiteLLM API call failed: {str(e)}")
+
+
+async def call_llm_with_tools_litellm_async(
+    base_url: str,
+    api_key: str,
+    model_id: str,
+    system_prompt: str = None,
+    user_prompt: str = None,
+    messages: List[Dict] = None,
+    temperature: float = 0.7,
+    max_tokens: int = 500,
+    max_retries: int = 3,
+    tools: List[Dict] = None,
+    tool_choice: str = "auto",
+    litellm_kwargs: Dict = None,
+) -> Union[str, Dict]:
+    import litellm
+
+    formatted_messages = _format_messages(system_prompt, user_prompt, messages)
+    kwargs = _litellm_kwargs(api_key, base_url, max_retries, litellm_kwargs)
+
+    try:
+        response = await litellm.acompletion(
+            model=model_id,
+            messages=formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            tool_choice=tool_choice if tools else None,
+            **kwargs,
+        )
+        return _handle_tool_response(response.choices[0].message)
+    except Exception as e:
+        raise LLMError(f"LiteLLM API call failed: {str(e)}")
+
+
 def extract_function_calls_to_tool_calls(llm_text: str) -> SimpleNamespace:
     """
     Scan the LLM's text output for a <function=NAME>{...}</function> pattern,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "curl-cffi<0.14",
     "google-genai>=1.56.0",
     "asyncpg",
+    "litellm>=1.60,<1.85", # LiteLLM AI gateway backend for LLMProvider (one provider, 100+ upstream backends)
 ]
 
 # required for spaceandtime agent as it uses old deps

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,314 @@
+"""Unit tests for the LiteLLM backend in core.llm and core.components.llm_provider.
+
+We load the two modules directly via importlib so the tests don't require the
+full project dependency tree (mcp, firecrawl, psycopg2, etc.) to be installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Direct-file module loaders. The package __init__ pulls in many optional
+# clients (firecrawl, mcp, etc.); we just want core.llm and the provider.
+# ---------------------------------------------------------------------------
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, rel_path: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, PROJECT_ROOT / rel_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# core.llm has no internal package imports, load standalone.
+llm = _load("core_llm_under_test", "core/llm.py")
+
+# core.components.llm_provider does `from ..llm import ...`. Stub the package
+# graph so the relative import resolves to the module above without dragging
+# in the rest of the core package (which has heavy optional deps like
+# psycopg2, firecrawl, mcp, etc.).
+core_pkg = ModuleType("core_pkg_under_test")
+core_pkg.__path__ = [str(PROJECT_ROOT / "core")]
+sys.modules["core_pkg_under_test"] = core_pkg
+sys.modules["core_pkg_under_test.llm"] = llm
+components_pkg = ModuleType("core_pkg_under_test.components")
+components_pkg.__path__ = [str(PROJECT_ROOT / "core" / "components")]
+sys.modules["core_pkg_under_test.components"] = components_pkg
+provider_spec = importlib.util.spec_from_file_location(
+    "core_pkg_under_test.components.llm_provider",
+    PROJECT_ROOT / "core" / "components" / "llm_provider.py",
+)
+provider_module = importlib.util.module_from_spec(provider_spec)
+sys.modules["core_pkg_under_test.components.llm_provider"] = provider_module
+provider_spec.loader.exec_module(provider_module)
+
+
+LLMProvider = provider_module.LLMProvider
+HEURIST_BACKEND = provider_module.HEURIST_BACKEND
+LITELLM_BACKEND = provider_module.LITELLM_BACKEND
+
+
+# ---------------------------------------------------------------------------
+# Mocked litellm.completion / litellm.acompletion responses
+# ---------------------------------------------------------------------------
+
+
+def _completion_response(content: str, tool_calls=None) -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+# ---------------------------------------------------------------------------
+# core.llm: low-level LiteLLM call functions
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmKwargs(unittest.TestCase):
+    def test_drop_params_default(self):
+        kwargs = llm._litellm_kwargs(None, None, 3, None)
+        self.assertIs(kwargs["drop_params"], True)
+        self.assertEqual(kwargs["num_retries"], 3)
+
+    def test_credentials_passed_when_set(self):
+        kwargs = llm._litellm_kwargs("sk", "https://x", 0, None)
+        self.assertEqual(kwargs["api_key"], "sk")
+        self.assertEqual(kwargs["api_base"], "https://x")
+
+    def test_user_kwargs_override_defaults(self):
+        kwargs = llm._litellm_kwargs(None, None, 3, {"drop_params": False, "num_retries": 7})
+        self.assertIs(kwargs["drop_params"], False)
+        self.assertEqual(kwargs["num_retries"], 7)
+
+
+class TestCallLlmLitellm(unittest.TestCase):
+    def test_returns_content_dict(self):
+        with patch("litellm.completion", return_value=_completion_response("4")):
+            out = llm.call_llm_litellm(
+                base_url=None,
+                api_key=None,
+                model_id="anthropic/claude-3-5-sonnet-20241022",
+                system_prompt="sys",
+                user_prompt="What is 2+2?",
+            )
+        self.assertEqual(out, {"content": "4"})
+
+    def test_propagates_tool_calls(self):
+        tool_call = SimpleNamespace(function=SimpleNamespace(name="get_weather", arguments='{"city":"Tokyo"}'))
+        with patch(
+            "litellm.completion",
+            return_value=_completion_response("", tool_calls=[tool_call]),
+        ):
+            out = llm.call_llm_with_tools_litellm(
+                base_url=None,
+                api_key=None,
+                model_id="anthropic/claude-3-5-sonnet-20241022",
+                system_prompt="sys",
+                user_prompt="weather?",
+                tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            )
+        self.assertIn("tool_calls", out)
+
+    def test_raises_llmerror_on_failure(self):
+        with patch("litellm.completion", side_effect=RuntimeError("net dead")):
+            with self.assertRaisesRegex(llm.LLMError, "LiteLLM API call failed"):
+                llm.call_llm_litellm(
+                    base_url=None,
+                    api_key=None,
+                    model_id="openai/gpt-4o",
+                    system_prompt="x",
+                    user_prompt="y",
+                )
+
+    def test_passes_temperature_and_max_tokens(self):
+        captured = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return _completion_response("ok")
+
+        with patch("litellm.completion", side_effect=fake_completion):
+            llm.call_llm_litellm(
+                base_url=None,
+                api_key=None,
+                model_id="openai/gpt-4o",
+                system_prompt="s",
+                user_prompt="u",
+                temperature=0.0,
+                max_tokens=64,
+                litellm_kwargs={"num_retries": 2},
+            )
+        self.assertEqual(captured["temperature"], 0.0)
+        self.assertEqual(captured["max_tokens"], 64)
+        self.assertEqual(captured["num_retries"], 2)
+        self.assertIs(captured["drop_params"], True)
+
+
+class TestCallLlmLitellmAsync(unittest.TestCase):
+    def test_async_returns_string(self):
+        async def run():
+            with patch("litellm.acompletion", return_value=_completion_response("hi")):
+                return await llm.call_llm_litellm_async(
+                    base_url=None,
+                    api_key=None,
+                    model_id="openai/gpt-4o",
+                    system_prompt="s",
+                    user_prompt="u",
+                )
+
+        out = asyncio.run(run())
+        self.assertEqual(out, "hi")
+
+    def test_async_with_tools_returns_dict(self):
+        tool_call = SimpleNamespace(function=SimpleNamespace(name="t", arguments="{}"))
+
+        async def run():
+            with patch(
+                "litellm.acompletion",
+                return_value=_completion_response("", tool_calls=[tool_call]),
+            ):
+                return await llm.call_llm_with_tools_litellm_async(
+                    base_url=None,
+                    api_key=None,
+                    model_id="openai/gpt-4o",
+                    system_prompt="s",
+                    user_prompt="u",
+                    tools=[{"type": "function", "function": {"name": "t"}}],
+                )
+
+        out = asyncio.run(run())
+        self.assertIn("tool_calls", out)
+
+
+# ---------------------------------------------------------------------------
+# LLMProvider: backend switch + dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestProviderInit(unittest.TestCase):
+    def setUp(self):
+        # Make sure HEURIST_* env vars exist so the heurist branch
+        # has something to read; tests don't actually call out.
+        self._saved = (
+            os.environ.get("HEURIST_BASE_URL"),
+            os.environ.get("HEURIST_API_KEY"),
+        )
+        os.environ["HEURIST_BASE_URL"] = "http://example.invalid"
+        os.environ["HEURIST_API_KEY"] = "k"
+
+    def tearDown(self):
+        base, key = self._saved
+        if base is None:
+            os.environ.pop("HEURIST_BASE_URL", None)
+        else:
+            os.environ["HEURIST_BASE_URL"] = base
+        if key is None:
+            os.environ.pop("HEURIST_API_KEY", None)
+        else:
+            os.environ["HEURIST_API_KEY"] = key
+
+    def test_default_backend_is_heurist(self):
+        p = LLMProvider()
+        self.assertEqual(p.provider, HEURIST_BACKEND)
+        self.assertEqual(p.base_url, "http://example.invalid")
+        self.assertEqual(p.api_key, "k")
+
+    def test_litellm_backend_does_not_pull_heurist_env(self):
+        p = LLMProvider(
+            provider=LITELLM_BACKEND,
+            large_model_id="anthropic/claude-3-5-sonnet-20241022",
+        )
+        self.assertEqual(p.provider, LITELLM_BACKEND)
+        self.assertIsNone(p.base_url)
+        self.assertIsNone(p.api_key)
+
+    def test_litellm_backend_accepts_explicit_credentials(self):
+        p = LLMProvider(
+            provider=LITELLM_BACKEND,
+            base_url="https://foundry/anthropic",
+            api_key="sk-ant-foundry",
+            large_model_id="anthropic/claude-sonnet-4-6",
+        )
+        self.assertEqual(p.base_url, "https://foundry/anthropic")
+        self.assertEqual(p.api_key, "sk-ant-foundry")
+
+    def test_unknown_backend_raises(self):
+        with self.assertRaisesRegex(ValueError, "Unknown LLM provider backend"):
+            LLMProvider(provider="bogus")
+
+
+class TestProviderDispatch(unittest.TestCase):
+    def test_heurist_dispatch_targets_openai_path(self):
+        os.environ["HEURIST_BASE_URL"] = "http://example.invalid"
+        os.environ["HEURIST_API_KEY"] = "k"
+        p = LLMProvider(large_model_id="some-heurist-model")
+        tools_fn, no_tools_fn, extra = p._dispatch()
+        self.assertEqual(tools_fn, llm.call_llm_with_tools)
+        self.assertEqual(no_tools_fn, llm.call_llm)
+        self.assertEqual(extra, {})
+
+    def test_litellm_dispatch_targets_litellm_path(self):
+        p = LLMProvider(
+            provider=LITELLM_BACKEND,
+            large_model_id="anthropic/claude-3-5-sonnet-20241022",
+            litellm_kwargs={"num_retries": 5},
+        )
+        tools_fn, no_tools_fn, extra = p._dispatch()
+        self.assertEqual(tools_fn, llm.call_llm_with_tools_litellm)
+        self.assertEqual(no_tools_fn, llm.call_llm_litellm)
+        self.assertEqual(extra, {"litellm_kwargs": {"num_retries": 5}})
+
+    def test_litellm_dispatch_omits_extra_when_no_kwargs(self):
+        p = LLMProvider(
+            provider=LITELLM_BACKEND,
+            large_model_id="openai/gpt-4o",
+        )
+        _, _, extra = p._dispatch()
+        self.assertEqual(extra, {})
+
+
+class TestProviderCall(unittest.TestCase):
+    def test_litellm_call_routes_through_litellm_completion(self):
+        async def run():
+            p = LLMProvider(
+                provider=LITELLM_BACKEND,
+                large_model_id="anthropic/claude-3-5-sonnet-20241022",
+            )
+            captured = {}
+
+            def fake(**kwargs):
+                captured.update(kwargs)
+                return _completion_response("4")
+
+            with patch("litellm.completion", side_effect=fake):
+                text, image_url, tool_back = await p.call(
+                    system_prompt="reply with 4",
+                    user_prompt="2+2?",
+                    temperature=0.0,
+                    max_tokens=32,
+                )
+            return captured, text, image_url, tool_back
+
+        captured, text, image_url, tool_back = asyncio.run(run())
+        self.assertEqual(text, "4")
+        self.assertIsNone(image_url)
+        self.assertIsNone(tool_back)
+        # litellm.completion was indeed called with the litellm-prefixed model
+        self.assertEqual(captured["model"], "anthropic/claude-3-5-sonnet-20241022")
+        self.assertIs(captured["drop_params"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13' and implementation_name == 'cpython'",
+    "python_full_version >= '3.14' and implementation_name == 'cpython'",
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "python_full_version == '3.12.*' and implementation_name == 'cpython'",
     "python_full_version < '3.12' and implementation_name == 'cpython'",
     "python_full_version >= '3.13' and implementation_name == 'pypy'",
@@ -1558,6 +1559,7 @@ dependencies = [
     { name = "flask", extra = ["async"] },
     { name = "google-cloud-bigquery" },
     { name = "google-genai" },
+    { name = "litellm" },
     { name = "loguru" },
     { name = "mcp" },
     { name = "openai" },
@@ -1602,6 +1604,7 @@ requires-dist = [
     { name = "flask", extras = ["async"], specifier = "==3.1.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.27.0" },
     { name = "google-genai", specifier = ">=1.56.0" },
+    { name = "litellm", specifier = ">=1.60,<1.85" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "mcp", specifier = "==1.6.0" },
     { name = "openai", specifier = "==1.71.0" },
@@ -1744,6 +1747,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1863,6 +1878,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.75.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/98/ea40c48fda5121af00e44c9c6d01a0cd8cb9987bb0ce91c6add917d9db9d/litellm-1.75.3.tar.gz", hash = "sha256:a6a0f33884f35a9391a9a4363043114d7f2513ab2e5c2e1fa54c56d695663764", size = 10104437, upload-time = "2025-08-08T14:58:09.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/1e/8ef7e7ac7d33f900ae44e9e3a33d668783034e414aa4d7191ae3e4068ec5/litellm-1.75.3-py3-none-any.whl", hash = "sha256:0ff3752b1f1c07f8a4b9a364b1595e2147ae640f1e77cd8312e6f6a5ca0f34ec", size = 8870578, upload-time = "2025-08-08T14:58:06.766Z" },
 ]
 
 [[package]]
@@ -3655,6 +3692,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "toolz"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4111,4 +4175,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/1b/431d0ebd6a1e9deaffc8627cc4d26fd869841f31a1429cab7443eced0766/yfinance-1.2.0.tar.gz", hash = "sha256:80cec643eb983330ca63debab1b5492334fa1e6338d82cb17dd4e7b95079cfab", size = 140501, upload-time = "2026-02-16T19:52:34.368Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/60/462859de757ac56830824da7e8cf314b8b0321af5853df867c84cd6c2128/yfinance-1.2.0-py2.py3-none-any.whl", hash = "sha256:1c27d1ebfc6275f476721cc6dba035a49d0cf9a806d6aa1785c9e10cf8a610d8", size = 130247, upload-time = "2026-02-16T19:52:33.109Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
                                                                                                                                
  ## Description                                                                                                                                                                                                     
                                                                                                                                                                                                                     
  This PR adds **LiteLLM as an embedded AI gateway backend** in `LLMProvider`, opt-in via `provider="litellm"`. It is *not* a separate proxy server. The framework imports the `litellm` SDK directly and routes     
  every completion through `litellm.completion` / `litellm.acompletion`, so a single `LLMProvider` instance can talk to OpenAI, Anthropic, Vertex AI, Bedrock, Azure, Cohere, Mistral, Groq, Ollama, and 90+ other   
  hosted backends without configuring each SDK individually.                                                                                                                                                         
                                                                                                                                                                                                                   
  **What it does:**                                                                                                                                                                                                  
  - Adds 4 new functions in `core/llm.py`: `call_llm_litellm`, `call_llm_with_tools_litellm`, plus async variants. Same call-site contract as the existing `call_llm` / `call_llm_with_tools`, but routes through
  LiteLLM.                                                                                                                                                                                                           
  - Adds a `provider` parameter to `LLMProvider.__init__` (default `"heurist"`, new option `"litellm"`). When `"litellm"`, the existing `call()` method dispatches to the new functions.
  - Adds `litellm>=1.60,<1.85` as a dependency.                                                                                                                                                                      
                                                                                                                                                                                                                     
  **Why:**                                                                                                                                                                                                           
  - One backend, many upstream providers. Users can run agents against Anthropic Sonnet, Bedrock Claude, Vertex AI Gemini, Azure GPT, Groq Llama, etc. by changing only `large_model_id` and the relevant env var.   
  - Credentials are resolved per-provider from env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`, `AZURE_API_KEY`, ...) by default, with optional `api_key` / `base_url` for OpenAI-compatible    
  custom endpoints (private LiteLLM proxies, Azure Foundry deployments, etc.).                                                                                                                                       
  - `drop_params=True` is on by default so kwargs that some providers reject (`presence_penalty` / `frequency_penalty` on Anthropic, Gemini, Bedrock; `response_format` on Bedrock; etc.) are silently dropped       
  instead of raising `UnsupportedParamsError`.                                                                                                                                                                       
                  
  **Backward compatibility:** the default backend stays `"heurist"`. All existing `LLMProvider(...)` call sites in `agents/`, `mesh/`, `interfaces/`, and `core/examples/` are unchanged.                            
                  
  **Usage:**                                                                                                                                                                                                         
                  
  ```python                                                                                                                                                                                                          
  from core.components.llm_provider import LLMProvider

  # Default Heurist gateway path, unchanged
  heurist = LLMProvider(                                                                                                                                                                                             
      base_url=HEURIST_BASE_URL,
      api_key=HEURIST_API_KEY,                                                                                                                                                                                       
      large_model_id=LARGE_MODEL_ID,
      tool_manager=tools,                                                                                                                                                                                            
  )               
                                                                                                                                                                                                                     
  # New LiteLLM backend; model uses LiteLLM's provider-prefixed name
  litellm_provider = LLMProvider(                                                                                                                                                                                    
      provider="litellm",
      large_model_id="anthropic/claude-3-5-sonnet-20241022",                                                                                                                                                         
      tool_manager=tools,                                                                                                                                                                                            
  )
                                                                                                                                                                                                                     
  text, image_url, tool_back = await litellm_provider.call(
      system_prompt="You are a helpful assistant.",                                                                                                                                                                  
      user_prompt="What is 2+2?",                                                                                                                                                                                    
      temperature=0.0,                                                                                                                                                                                               
  )                                                                                                                                                                                                                  
                  
```                                                                                                                                          
                  
  ##How Has This Been Tested?                                                                                                                                                                                          
                  
  ### Unit tests (17 / 17 pass)                                                                                                                                                                                          
                  
  Added `tests/test_litellm_provider.py` covering:                                                                                                                                                                     
  - `_litellm_kwargs` builder (drop_params default, credential propagation, user-kwargs override).
  - `call_llm_litellm` returns content dict, propagates tool calls, raises `LLMError` on failure, forwards temperature / `max_tokens` / `litellm_kwargs`.                                                                    
  - `call_llm_litellm_async` and `call_llm_with_tools_litellm_async` variants.                                                                       
  - `LLMProvider` init: default backend, litellm backend skips Heurist env, accepts explicit credentials, rejects unknown backend.                                                                                     
  - `LLMProvider._dispatch` picks the correct call functions for each backend.                                                                                                                                         
  - `LLMProvider.call()` with provider="litellm" actually routes through `litellm.completion`.                                                                                                                           

```bash                                                                                                                                                                                                                     
  $ ruff check --select=I --line-length=120 core/llm.py core/components/llm_provider.py tests/test_litellm_provider.py                                                                                               
  All checks passed!                                                                                                                                                                                                 
                                                                                                                                                                                                                     
  $ ruff format --check --line-length=120 core/llm.py core/components/llm_provider.py tests/test_litellm_provider.py                                                                                                 
  3 files already formatted
                                                                                                                                                                                                                     
  $ pytest tests/test_litellm_provider.py
  ======================= 17 passed in 0.66s =======================                                                                                                                                                 
                  
  Live E2E (Anthropic Claude Sonnet 4-6 via Azure AI Foundry)                                                                                                                                                        
   
  Three scenarios verified end-to-end against a real provider:                                                                                                                                                       
                  
  === call() :: anthropic/claude-sonnet-4-6 ===                                                                                                                                                                      
    text       : '4'                                                                                                                                                                                                 
    image_url  : None                                                                                                                                                                                                
    tool_back  : None                                                                                                                                                                                                
    PASS                                                                                                                                                                                                             
                  
  === drop_params=True default :: anthropic/claude-sonnet-4-6 (presence_penalty=0.5) ===                                                                                                                             
    text       : '4'
    PASS  (Anthropic accepted; presence_penalty silently dropped)                                                                                                                                                    
                                                                                                                                                                                                                     
  === tools=[get_weather] :: anthropic/claude-sonnet-4-6 ===                                                                                                                                                         
    text       : '\nIt is sunny and 22C in Tokyo'                                                                                                                                                                    
    PASS  (LiteLLM parsed Anthropic tool call, dispatched through tool_manager.execute_tool, result merged into the text response)                                                                                   
  ```
                                                                                                                                                                                                                     
  The tool-calling test instantiates a FakeToolManager whose execute_tool returns a string, then verifies the full chain: Anthropic returns tool_calls, LiteLLM normalizes the response shape, LLMProvider.call()    
  extracts the call, dispatches to tool_manager.execute_tool, and merges the result back into the text.                                                                                                              
                                                                                                                                                                                                                     
  ## Reproduce                                                                                                                                                                                                          
```bash   
  uv sync                                                                                                                                                                                                            
  export ANTHROPIC_API_KEY=sk-ant-...
  uv run pytest tests/test_litellm_provider.py
```

```python                                                                                                                                                                                             
  import asyncio
  from core.components.llm_provider import LLMProvider                                                                                                                                                               
                                                                                                                                                                                                                     
  p = LLMProvider(
      provider='litellm',                                                                                                                                                                                            
      large_model_id='anthropic/claude-3-5-sonnet-20241022',
  )                                                                                                                                                                                                                  
  text, _, _ = asyncio.run(p.call(
      system_prompt='Reply with just the number.',                                                                                                                                                                   
      user_prompt='2+2?',                                                                                                                                                                                            
  ))
  print(text)                                                                                                                                                                                                         
```

  ## Checklist                                                                                                                                                                                                       
   
  - [x] **Documentation**: I have updated or added documentation where needed (in code, README, or other docs).                                                                                                      
  - [x] **Tests**:
    - [x] Added or updated tests to cover my changes. All tests pass locally on my machine.                                                                                                                          
    - [ ] I have added a test script in `mesh/tests/` that instantiates my mesh agent and calls its `handle_message` with example input.                                                                             
    - [ ] No tests needed for this PR.
  - [ ] **Metadata** (for Heurist Mesh Agents): I have filled out or updated the agent's metadata (name, description, author, inputs/outputs, etc.) if relevant.                                                     
  - [x] **No Duplicates**: I have checked that no other PR is addressing the same issue or feature.                                                                                                                  
  - [x] **No Breaking Changes**: The changes in this PR do not break existing functionality. If they do, I have clearly explained the impact below.                                                                  


## Additional Notes
<!--
  Add any additional comments, references, or screenshots here.
  If your change has significant design implications or requires special instructions,
  please include those details.
-->
