### PR TITLE
feat(mesh): add Xquik fallback and repair Mesh docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The Heurist Agent Framework is built on a modular architecture that allows an AI
 ### Get Started with Mesh
 
 - **Mesh Portal**: [mesh.heurist.ai](https://mesh.heurist.ai) - Browse agents and deploy dedicated MCP servers
-- **REST API**: [API Documentation](https://docs.heurist.ai/dev-guide/heurist-mesh/)
+- **REST API**: [API Documentation](https://docs.heurist.ai/heurist-mesh/overview)
 - **X402 API**: [mesh.heurist.xyz/x402/agents](https://mesh.heurist.xyz/x402/agents) - Pay-per-use with USDC on Base
 - **Full Agent List**: [View all agents](./mesh/README.md#appendix-all-available-mesh-agents)
 

--- a/mesh/README.md
+++ b/mesh/README.md
@@ -7,7 +7,7 @@
 ## Using Mesh Agents
 
 > [!NOTE]
-> For detailed API documentation including examples of both synchronous and asynchronous usage, please refer to the [official Heurist Mesh documentation](https://docs.heurist.ai/dev-guide/heurist-mesh/).
+> For detailed API documentation including examples of both synchronous and asynchronous usage, please refer to the [official Heurist Mesh documentation](https://docs.heurist.ai/heurist-mesh/overview).
 
 Mesh agents hosted by Heurist can be accessed via two interfaces:
 
@@ -329,7 +329,7 @@ Test inputs are stored in [test_inputs.json](../heurist-mesh-client/examples/tes
 | TokenResolverAgent | Find tokens by address/symbol/name/CoinGecko ID, return normalized profiles and top DEX pools. Pulls extra context (sites/socials/funding/indicators) where available. | • token_search<br>• token_profile | [Source](./agents/token_resolver_agent.py) | CoinGecko, DexScreener, Bitquery (Solana), GMGN/Unifai, Yahoo Finance (optional), Coinsider (optional) |
 | TrendingTokenAgent | Aggregates trending tokens from GMGN, CoinGecko, Pump.fun, Dexscreener, and Twitter discussions. | • get_trending_tokens<br>• get_market_summary | [Source](./agents/trending_token_agent.py) | GMGN, CoinGecko, Dexscreener, Elfa, AIXBT, Telegram |
 | TruthSocialAgent | This agent can retrieve and analyze posts from Donald Trump on Truth Social. | • get_trump_posts | [Source](./agents/truth_social_agent.py) | Apify |
-| TwitterInfoAgent | This agent fetches a Twitter user's profile information and recent tweets. It's useful for getting project updates or tracking key opinion leaders (KOLs) in the space. | • get_user_tweets<br>• get_twitter_detail<br>• get_general_search | [Source](./agents/twitter_info_agent.py) | Twitter API |
+| TwitterInfoAgent | This agent fetches a Twitter user's profile information and recent tweets. It's useful for getting project updates or tracking key opinion leaders (KOLs) in the space. | • get_user_tweets<br>• get_twitter_detail<br>• get_general_search | [Source](./agents/twitter_info_agent.py) | Twitter API, Xquik, Apify |
 | TwitterIntelligenceAgent | Twitter/X tools (timeline, tweet detail, search) | • user_timeline<br>• tweet_detail<br>• twitter_search | [Source](./agents/twitter_intelligence_agent.py) | Twitter/X, Influential mentions |
 | UnifaiMeteoraInfoAgent | This agent provides Meteora pool information using UnifAI's API, including trending DLMM pools, dynamic AMM pools, and DLMM pool search functionality | • get_trending_dlmm_pools<br>• search_dynamic_amm_pools<br>• search_dlmm_pools | [Source](./agents/unifai_meteora_info_agent.py) | UnifAI |
 | UnifaiTokenAnalysisAgent | This agent provides token analysis using UnifAI's API, including GMGN trend analysis (GMGN is a memecoin trading platform) and comprehensive token analysis for various cryptocurrencies | • get_gmgn_trend<br>• get_gmgn_token_info<br>• analyze_token | [Source](./agents/unifai_token_analysis_agent.py) | UnifAI |

--- a/mesh/agents/twitter_info_agent.py
+++ b/mesh/agents/twitter_info_agent.py
@@ -10,13 +10,14 @@ from apify_client import ApifyClient
 from dotenv import load_dotenv
 from loguru import logger
 
-from decorators import with_cache
+from decorators import with_cache, with_retry
 from mesh.mesh_agent import MeshAgent
 
 load_dotenv()
 
 DEFAULT_TIMELINE_LIMIT = 20
 FXTWITTER_API_BASE = "https://api.fxtwitter.com"
+XQUIK_API_BASE = "https://xquik.com/api/v1"
 
 
 def _clean_tweet_text(text: str) -> str:
@@ -57,17 +58,18 @@ def _format_date_only(timestamp: str) -> str:
 class TwitterInfoAgent(MeshAgent):
     def __init__(self):
         super().__init__()
-        self.api_key = os.getenv("APIDANCE_API_KEY")
-        if not self.api_key:
-            raise ValueError("APIDANCE_API_KEY environment variable is required")
+        self.api_key = (os.getenv("APIDANCE_API_KEY") or "").strip()
+        self.xquik_api_key = (os.getenv("XQUIK_API_KEY") or "").strip()
+        if not self.api_key and not self.xquik_api_key:
+            raise ValueError("APIDANCE_API_KEY or XQUIK_API_KEY environment variable is required")
 
         self.base_url = "https://api.apidance.pro"
-        self.headers = {"apikey": self.api_key}
+        self.headers = {"apikey": self.api_key} if self.api_key else {}
+        self.xquik_base_url = os.getenv("XQUIK_API_BASE_URL", XQUIK_API_BASE).rstrip("/")
+        self.xquik_headers = {"x-api-key": self.xquik_api_key} if self.xquik_api_key else {}
 
-        self.apify_api_key = os.getenv("APIFY_API_KEY")
-        if not self.apify_api_key:
-            raise ValueError("APIFY_API_KEY environment variable is required")
-        self.apify_client = ApifyClient(self.apify_api_key)
+        self.apify_api_key = (os.getenv("APIFY_API_KEY") or "").strip()
+        self.apify_client = ApifyClient(self.apify_api_key) if self.apify_api_key else None
         self.apify_actor_id = "practicaltools/cheap-simple-twitter-api"
         self.apify_search_actor_id = "gdN28kzr6QsU4nVh8"
 
@@ -78,7 +80,7 @@ class TwitterInfoAgent(MeshAgent):
                 "author": "Heurist team",
                 "author_address": "0x7d9d1821d15B9e0b8Ab98A058361233E255E405D",
                 "description": "This agent fetches a Twitter user's profile information and recent tweets. It's useful for getting project updates or tracking key opinion leaders (KOLs) in the space.",
-                "external_apis": ["Twitter API"],
+                "external_apis": ["Twitter API", "Xquik", "Apify"],
                 "tags": ["Twitter"],
                 "verified": True,
                 "image_url": "https://raw.githubusercontent.com/heurist-network/heurist-agent-framework/refs/heads/main/mesh/images/Twitter.png",
@@ -231,6 +233,7 @@ class TwitterInfoAgent(MeshAgent):
             "source": f"x.com/{username}/status/{tid}" if username and tid else "",
             "author": {
                 "id": user.get("id_str") or "",
+                "username": username,
                 "name": user.get("name", ""),
                 "verified": bool(user.get("verified", False)),
                 "followers": _to_int(user.get("followers_count")),
@@ -265,6 +268,174 @@ class TwitterInfoAgent(MeshAgent):
             result["quoted_tweet_id"] = str(tweet["related_tweet_id"])
 
         return result
+
+    def _simplify_xquik_profile(self, profile: Dict) -> Dict:
+        return {
+            "id_str": str(profile.get("id") or ""),
+            "name": profile.get("name", ""),
+            "screen_name": profile.get("username", ""),
+            "description": profile.get("description", ""),
+            "followers_count": _to_int(profile.get("followers")),
+            "friends_count": _to_int(profile.get("following")),
+            "statuses_count": _to_int(profile.get("statusesCount")),
+            "verified": bool(profile.get("verified", False)),
+            "created_at": profile.get("createdAt", ""),
+        }
+
+    def _simplify_xquik_tweet(self, tweet: Dict, fallback_author: Optional[Dict] = None) -> Dict:
+        author = tweet.get("author") or fallback_author or {}
+        username = author.get("username") or author.get("screen_name") or ""
+        tid = str(tweet.get("id") or tweet.get("tweet_id") or "")
+        text = tweet.get("text") or ""
+        source = tweet.get("url") or (f"x.com/{username}/status/{tid}" if username and tid else "")
+
+        def _type(t: Dict) -> str:
+            if t.get("retweeted_tweet"):
+                return "retweet"
+            if t.get("isReply"):
+                return "reply"
+            if t.get("isQuoteStatus") or t.get("quoted_tweet"):
+                return "quote"
+            return t.get("type") or "tweet"
+
+        result = {
+            "id": tid,
+            "text": _clean_tweet_text(text),
+            "created_at": _format_date_only(tweet.get("createdAt", "")),
+            "source": source,
+            "author": {
+                "id": str(author.get("id") or ""),
+                "username": username,
+                "name": author.get("name", ""),
+                "verified": bool(author.get("verified", False)),
+                "followers": _to_int(author.get("followers")),
+            },
+            "engagement": {
+                "likes": _to_int(tweet.get("likeCount")),
+                "replies": _to_int(tweet.get("replyCount")),
+                "retweets": _to_int(tweet.get("retweetCount")),
+                "quotes": _to_int(tweet.get("quoteCount")),
+                "views": _to_int(tweet.get("viewCount")),
+            },
+            "type": _type(tweet),
+        }
+
+        if tweet.get("entities"):
+            result["entities"] = tweet.get("entities")
+        if tweet.get("media"):
+            result["media"] = tweet.get("media")
+        if tweet.get("inReplyToId"):
+            result["in_reply_to_tweet_id"] = tweet.get("inReplyToId")
+        if tweet.get("inReplyToUsername"):
+            result["in_reply_to_user"] = tweet.get("inReplyToUsername")
+
+        quoted_tweet = tweet.get("quoted_tweet")
+        if quoted_tweet:
+            result["quoted_tweet"] = self._simplify_xquik_tweet(quoted_tweet)
+
+        return result
+
+    @with_cache(ttl_seconds=300)
+    @with_retry(max_retries=3, delay=1.0)
+    async def _xquik_request(self, path: str, params: Optional[Dict] = None) -> Dict:
+        if not self.xquik_api_key:
+            return {"error": "XQUIK_API_KEY environment variable is required"}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.xquik_base_url}{path}",
+                headers=self.xquik_headers,
+                params=params,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                data = await response.json()
+                if response.status >= 400:
+                    message = data.get("message") or data.get("error") or f"Xquik API returned status {response.status}"
+                    return {"error": message}
+                return data
+
+    @with_cache(ttl_seconds=300)
+    async def get_xquik_user_id(self, identifier: str) -> Dict:
+        clean_identifier = self._clean_username(identifier)
+        profile = await self._xquik_request(f"/x/users/{clean_identifier}")
+        if "error" in profile:
+            return profile
+        return {"profile": self._simplify_xquik_profile(profile)}
+
+    @with_cache(ttl_seconds=300)
+    async def get_xquik_tweets(
+        self, identifier: str, limit: int = DEFAULT_TIMELINE_LIMIT, cursor: Optional[str] = None
+    ) -> Dict:
+        clean_identifier = self._clean_username(identifier)
+        params = {"includeReplies": "false", "limit": min(limit, 200)}
+        if cursor:
+            params["cursor"] = cursor
+        tweets_data = await self._xquik_request(f"/x/users/{clean_identifier}/tweets", params=params)
+        if "error" in tweets_data:
+            return tweets_data
+
+        tweets = tweets_data.get("tweets") or []
+        return {
+            "tweets": [self._simplify_xquik_tweet(tweet) for tweet in tweets[:limit]],
+            "next_cursor": tweets_data.get("next_cursor"),
+        }
+
+    @with_cache(ttl_seconds=300)
+    async def get_xquik_tweet_detail(self, tweet_id: str, cursor: Optional[str] = None) -> Dict:
+        params = {"cursor": cursor} if cursor else None
+        tweet_data = await self._xquik_request(f"/x/tweets/{tweet_id}")
+        if "error" in tweet_data:
+            return tweet_data
+
+        tweet = tweet_data.get("tweet") or tweet_data
+        result = {"main_tweet": self._simplify_xquik_tweet(tweet, tweet_data.get("author") or {})}
+
+        thread_data = await self._xquik_request(f"/x/tweets/{tweet_id}/thread", params=params)
+        if "error" not in thread_data:
+            thread_tweets = [
+                self._simplify_xquik_tweet(item)
+                for item in (thread_data.get("tweets") or [])
+                if str(item.get("id") or "") != tweet_id
+            ]
+            if thread_tweets:
+                result["thread_tweets"] = thread_tweets
+
+        replies_data = await self._xquik_request(f"/x/tweets/{tweet_id}/replies", params=params)
+        if "error" not in replies_data:
+            replies = [self._simplify_xquik_tweet(item) for item in (replies_data.get("tweets") or [])]
+            if replies:
+                result["replies"] = replies
+
+        next_cursor = (thread_data.get("next_cursor") if "error" not in thread_data else None) or (
+            replies_data.get("next_cursor") if "error" not in replies_data else None
+        )
+        if next_cursor:
+            result["next_cursor"] = next_cursor
+
+        return result
+
+    @with_cache(ttl_seconds=300)
+    async def xquik_general_search(
+        self, query: str, sort_by: str = "Latest", cursor: Optional[str] = None, limit: Optional[int] = None
+    ) -> Dict:
+        params = {"q": query, "queryType": "Top" if sort_by == "Top" else "Latest"}
+        if cursor:
+            params["cursor"] = cursor
+        if limit:
+            params["limit"] = min(limit, 50)
+
+        search_data = await self._xquik_request("/x/tweets/search", params=params)
+        if "error" in search_data:
+            return search_data
+
+        tweets = search_data.get("tweets") or []
+        simplified = [self._simplify_xquik_tweet(tweet) for tweet in tweets]
+        return {
+            "query": query,
+            "tweets": simplified,
+            "result_count": len(simplified),
+            "next_cursor": search_data.get("next_cursor"),
+        }
 
     # ------------------------------------------------------------------------
     #                      ARTICLE READING METHODS (FXTwitter)
@@ -375,6 +546,7 @@ class TwitterInfoAgent(MeshAgent):
             "source": f"x.com/{username}/status/{tid}" if username and tid else "",
             "author": {
                 "id": str(author.get("id") or ""),
+                "username": username,
                 "name": author.get("name") or "",
                 "verified": bool(author.get("isVerified") or author.get("isBlueVerified") or False),
                 "followers": _to_int(author.get("followers")),
@@ -399,6 +571,9 @@ class TwitterInfoAgent(MeshAgent):
 
     async def _apify_get_user_timeline(self, username: str, limit: int = 20) -> Dict:
         """Fallback: Get user timeline using Apify practicaltools actor."""
+        if not self.apify_client:
+            return {"error": "APIFY_API_KEY environment variable is required"}
+
         clean_username = self._clean_username(username)
         logger.info(f"Apify fallback: fetching timeline for @{clean_username}")
 
@@ -430,6 +605,9 @@ class TwitterInfoAgent(MeshAgent):
 
     async def _apify_general_search(self, query: str, limit: int = 20) -> Dict:
         """Fallback: Search tweets using Apify advanced search actor."""
+        if not self.apify_client:
+            return {"error": "APIFY_API_KEY environment variable is required"}
+
         logger.info(f"Apify fallback: searching for '{query}'")
 
         run_input = {
@@ -455,6 +633,9 @@ class TwitterInfoAgent(MeshAgent):
 
     async def _apify_get_tweet_detail(self, tweet_id: str) -> Dict:
         """Fallback: Get single tweet detail using Apify practicaltools tweet/by_ids endpoint."""
+        if not self.apify_client:
+            return {"error": "APIFY_API_KEY environment variable is required"}
+
         logger.info(f"Apify fallback: fetching tweet detail for {tweet_id}")
 
         run_input = {"endpoint": "tweet/by_ids", "parameters": {"tweet_ids": tweet_id}}
@@ -478,6 +659,9 @@ class TwitterInfoAgent(MeshAgent):
     async def get_user_id(self, identifier: str) -> Dict:
         """Fetch Twitter user ID and profile information using GraphQL endpoint"""
         try:
+            if not self.api_key:
+                return {"error": "APIDANCE_API_KEY environment variable is required"}
+
             if self._is_numeric_id(identifier):
                 logger.warning(
                     f"Numeric user ID {identifier} not supported by GraphQL endpoint, will try Apify fallback"
@@ -527,6 +711,9 @@ class TwitterInfoAgent(MeshAgent):
 
     @with_cache(ttl_seconds=300)
     async def get_tweets(self, user_id: str, limit: int = DEFAULT_TIMELINE_LIMIT, cursor: Optional[str] = None) -> Dict:
+        if not self.api_key:
+            return {"error": "APIDANCE_API_KEY environment variable is required"}
+
         params = {"user_id": user_id, "count": min(limit, 50)}
         if cursor:
             params["cursor"] = cursor
@@ -546,6 +733,9 @@ class TwitterInfoAgent(MeshAgent):
 
     @with_cache(ttl_seconds=300)
     async def get_tweet_detail(self, tweet_id: str, cursor: Optional[str] = None) -> Dict:
+        if not self.api_key:
+            return {"error": "APIDANCE_API_KEY environment variable is required"}
+
         params = {"tweet_id": tweet_id}
         if cursor:
             params["cursor"] = cursor
@@ -638,6 +828,9 @@ class TwitterInfoAgent(MeshAgent):
     async def general_search(
         self, query: str, sort_by: str = "Latest", cursor: Optional[str] = None, limit: Optional[int] = None
     ) -> Dict:
+        if not self.api_key:
+            return {"error": "APIDANCE_API_KEY environment variable is required"}
+
         if " " in query and not (query.startswith('"') and query.endswith('"')):
             logger.warning(f"Multi-word search query detected: '{query}' (likely sparse results).")
         params = {"q": query, "sort_by": sort_by}
@@ -696,6 +889,21 @@ class TwitterInfoAgent(MeshAgent):
                     apidance_failed = True
 
             if apidance_failed:
+                if self.xquik_api_key:
+                    logger.warning(
+                        f"Primary API unavailable for @{self._clean_username(identifier)}, using Xquik fallback"
+                    )
+                    profile_result = await self.get_xquik_user_id(identifier)
+                    tweets_result = await self.get_xquik_tweets(identifier, limit, cursor)
+                    if "error" not in profile_result and "error" not in tweets_result:
+                        return {
+                            "twitter_data": {
+                                "profile": profile_result.get("profile", {}),
+                                "tweets": tweets_result.get("tweets", []),
+                            },
+                            "next_cursor": tweets_result.get("next_cursor"),
+                        }
+
                 logger.warning(f"Primary API unavailable for @{self._clean_username(identifier)}, using Apify fallback")
                 fallback_result = await self._apify_get_user_timeline(identifier, limit)
                 if "error" in fallback_result:
@@ -721,7 +929,11 @@ class TwitterInfoAgent(MeshAgent):
 
             tweet_detail_result = await self.get_tweet_detail(tweet_id, cursor)
 
-            # Fallback to Apify if APIDance fails
+            if "error" in tweet_detail_result and self.xquik_api_key:
+                logger.warning(f"Primary API unavailable for tweet {tweet_id}, using Xquik fallback")
+                tweet_detail_result = await self.get_xquik_tweet_detail(tweet_id, cursor)
+
+            # Fallback to Apify if configured providers fail
             if "error" in tweet_detail_result:
                 logger.warning(f"Primary API unavailable for tweet {tweet_id}, using Apify fallback")
                 tweet_detail_result = await self._apify_get_tweet_detail(tweet_id)
@@ -790,6 +1002,12 @@ class TwitterInfoAgent(MeshAgent):
 
             if not apidance_failed:
                 return {"search_data": search_result}
+
+            if self.xquik_api_key:
+                logger.warning(f"Primary search API unavailable for query '{query}', using Xquik fallback")
+                fallback_result = await self.xquik_general_search(query, sort_by=sort_by, cursor=cursor, limit=limit)
+                if "error" not in fallback_result:
+                    return {"search_data": fallback_result}
 
             logger.warning(f"Primary search API unavailable for query '{query}', using Apify fallback")
             fallback_result = await self._apify_general_search(query, limit=limit)

--- a/mesh/tests/twitter_info_agent_xquik.py
+++ b/mesh/tests/twitter_info_agent_xquik.py
@@ -1,0 +1,124 @@
+import asyncio
+import os
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import yaml
+
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+TwitterInfoAgent = import_module("mesh.agents.twitter_info_agent").TwitterInfoAgent
+
+
+PROFILE = {
+    "id": "42",
+    "username": "xquikcom",
+    "name": "Xquik",
+    "description": "X automation API",
+    "followers": 1200,
+    "following": 100,
+    "verified": True,
+    "createdAt": "2026-05-01T00:00:00Z",
+}
+
+MAIN_TWEET = {
+    "id": "1234567890",
+    "text": "Xquik timeline item",
+    "createdAt": "2026-05-16T12:00:00Z",
+    "url": "https://x.com/xquikcom/status/1234567890",
+    "likeCount": 4,
+    "retweetCount": 2,
+    "replyCount": 1,
+    "quoteCount": 0,
+    "viewCount": 100,
+    "author": PROFILE,
+}
+
+
+async def run_xquik_agent_examples() -> dict:
+    os.environ.pop("APIDANCE_API_KEY", None)
+    os.environ.pop("APIFY_API_KEY", None)
+    os.environ["XQUIK_API_KEY"] = "test-xquik-key"
+
+    agent = TwitterInfoAgent()
+    assert agent.xquik_headers == {"x-api-key": "test-xquik-key"}
+    requests = []
+
+    async def fake_xquik_request(path: str, params: dict | None = None) -> dict:
+        requests.append((path, params))
+        if path == "/x/users/xquikcom":
+            return PROFILE
+        if path == "/x/users/xquikcom/tweets":
+            return {"tweets": [MAIN_TWEET], "has_next_page": False, "next_cursor": ""}
+        if path == "/x/tweets/search":
+            return {"tweets": [MAIN_TWEET], "has_next_page": False, "next_cursor": ""}
+        if path == "/x/tweets/1234567890":
+            return {"tweet": MAIN_TWEET, "author": PROFILE}
+        if path == "/x/tweets/1234567890/thread":
+            return {
+                "tweets": [
+                    MAIN_TWEET,
+                    {
+                        **MAIN_TWEET,
+                        "id": "1234567891",
+                        "text": "Thread follow-up",
+                        "url": "https://x.com/xquikcom/status/1234567891",
+                    },
+                ],
+                "has_next_page": False,
+                "next_cursor": "",
+            }
+        if path == "/x/tweets/1234567890/replies":
+            return {
+                "tweets": [
+                    {
+                        **MAIN_TWEET,
+                        "id": "1234567892",
+                        "text": "Reply item",
+                        "url": "https://x.com/xquikcom/status/1234567892",
+                        "isReply": True,
+                    }
+                ],
+                "has_next_page": False,
+                "next_cursor": "",
+            }
+        return {"error": f"Unexpected Xquik path: {path}"}
+
+    agent._xquik_request = fake_xquik_request
+
+    test_cases = {
+        "xquik_user_tweets": {
+            "tool": "get_user_tweets",
+            "tool_arguments": {"username": "xquikcom", "limit": 5},
+        },
+        "xquik_search": {
+            "tool": "get_general_search",
+            "tool_arguments": {"q": "xquik", "limit": 5},
+        },
+        "xquik_tweet_detail": {
+            "tool": "get_twitter_detail",
+            "tool_arguments": {"tweet_id": "1234567890"},
+        },
+    }
+
+    results = {}
+    for name, params in test_cases.items():
+        output = await agent.handle_message(params)
+        results[name] = {"input": params, "output": output}
+
+    timeline = results["xquik_user_tweets"]["output"]["data"]["twitter_data"]
+    assert timeline["profile"]["screen_name"] == "xquikcom"
+    assert timeline["tweets"][0]["author"]["username"] == "xquikcom"
+    assert ("/x/users/xquikcom/tweets", {"includeReplies": "false", "limit": 5}) in requests
+    assert results["xquik_search"]["output"]["data"]["search_data"]["result_count"] == 1
+    assert results["xquik_tweet_detail"]["output"]["data"]["tweet_data"]["thread_tweets"][0]["id"] == "1234567891"
+
+    return results
+
+
+if __name__ == "__main__":
+    example_results = asyncio.run(run_xquik_agent_examples())
+    output_path = Path(__file__).with_name("twitter_info_agent_xquik_example.yaml")
+    output_path.write_text(yaml.safe_dump(example_results, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    print(f"Saved {output_path}")

--- a/mesh/tests/twitter_info_agent_xquik_example.yaml
+++ b/mesh/tests/twitter_info_agent_xquik_example.yaml
@@ -1,0 +1,130 @@
+xquik_user_tweets:
+  input:
+    tool: get_user_tweets
+    tool_arguments:
+      username: xquikcom
+      limit: 5
+  output:
+    data:
+      twitter_data:
+        profile:
+          id_str: '42'
+          name: Xquik
+          screen_name: xquikcom
+          description: X automation API
+          followers_count: 1200
+          friends_count: 100
+          statuses_count: 0
+          verified: true
+          created_at: '2026-05-01T00:00:00Z'
+        tweets:
+        - id: '1234567890'
+          text: Xquik timeline item
+          created_at: '2026-05-16'
+          source: https://x.com/xquikcom/status/1234567890
+          author:
+            id: '42'
+            username: xquikcom
+            name: Xquik
+            verified: true
+            followers: 1200
+          engagement:
+            likes: 4
+            replies: 1
+            retweets: 2
+            quotes: 0
+            views: 100
+          type: tweet
+      next_cursor: ''
+xquik_search:
+  input:
+    tool: get_general_search
+    tool_arguments:
+      q: xquik
+      limit: 5
+  output:
+    data:
+      search_data:
+        query: xquik
+        tweets:
+        - id: '1234567890'
+          text: Xquik timeline item
+          created_at: '2026-05-16'
+          source: https://x.com/xquikcom/status/1234567890
+          author:
+            id: '42'
+            username: xquikcom
+            name: Xquik
+            verified: true
+            followers: 1200
+          engagement:
+            likes: 4
+            replies: 1
+            retweets: 2
+            quotes: 0
+            views: 100
+          type: tweet
+        result_count: 1
+        next_cursor: ''
+xquik_tweet_detail:
+  input:
+    tool: get_twitter_detail
+    tool_arguments:
+      tweet_id: '1234567890'
+  output:
+    data:
+      tweet_data:
+        main_tweet:
+          id: '1234567890'
+          text: Xquik timeline item
+          created_at: '2026-05-16'
+          source: https://x.com/xquikcom/status/1234567890
+          author:
+            id: '42'
+            username: xquikcom
+            name: Xquik
+            verified: true
+            followers: 1200
+          engagement:
+            likes: 4
+            replies: 1
+            retweets: 2
+            quotes: 0
+            views: 100
+          type: tweet
+        thread_tweets:
+        - id: '1234567891'
+          text: Thread follow-up
+          created_at: '2026-05-16'
+          source: https://x.com/xquikcom/status/1234567891
+          author:
+            id: '42'
+            username: xquikcom
+            name: Xquik
+            verified: true
+            followers: 1200
+          engagement:
+            likes: 4
+            replies: 1
+            retweets: 2
+            quotes: 0
+            views: 100
+          type: tweet
+        replies:
+        - id: '1234567892'
+          text: Reply item
+          created_at: '2026-05-16'
+          source: https://x.com/xquikcom/status/1234567892
+          author:
+            id: '42'
+            username: xquikcom
+            name: Xquik
+            verified: true
+            followers: 1200
+          engagement:
+            likes: 4
+            replies: 1
+            retweets: 2
+            quotes: 0
+            views: 100
+          type: reply


### PR DESCRIPTION
## Description

Adds Xquik as an optional provider for `TwitterInfoAgent`. When the primary
provider is unavailable or unconfigured, `XQUIK_API_KEY` enables profile
lookup, timelines, search, tweet detail, thread context, and replies before the
agent uses its final fallback.

The integration preserves the existing response shape, sends credentials only
through environment-backed request headers, forwards requested timeline limits,
updates agent metadata, and includes mocked examples that require no live key.

## Independent Repository Fix

The API documentation links in both `README.md` and `mesh/README.md` redirected
to a 404 page. They now point to the current Heurist Mesh overview, which returns
HTTP 200.

## Related Issues / Tickets

None.

## How Has This Been Tested?

- `uv run --python 3.12 python mesh/tests/twitter_info_agent_xquik.py`
- `uv run --python 3.12 python -m py_compile mesh/agents/twitter_info_agent.py mesh/tests/twitter_info_agent_xquik.py`
- `uv run --python 3.12 ruff check --line-length=120 mesh/agents/twitter_info_agent.py mesh/tests/twitter_info_agent_xquik.py`
- `uv run --python 3.12 ruff format --check --line-length=120 mesh/agents/twitter_info_agent.py mesh/tests/twitter_info_agent_xquik.py`
- `git diff --check`
- Confirmed the parser uses Xquik's default v1 payload keys.
- Added a regression assertion for the exact environment-backed request header.
- Rebased the single signed commit onto the current upstream `main`.
- Old documentation URL: redirect followed by HTTP 404.
- New documentation URL: redirect followed by HTTP 200.

## Checklist

- [x] **Documentation**: Updated agent metadata, provider table, and broken API documentation links.
- [x] **Tests**:
  - [x] Added a mocked agent test script with saved YAML output.
  - [ ] No tests needed for this PR.
- [x] **Metadata**: Updated `TwitterInfoAgent` metadata.
- [x] **No Duplicates**: Checked repository content and open or closed issues and pull requests.
- [x] **No Breaking Changes**: Existing providers and tool response shapes remain supported.

Xquik is an independent third-party service. Not affiliated with X Corp.
"Twitter" and "X" are trademarks of X Corp.