### PR TITLE
feat: add fastCRW search client

### DIFF
--- a/core/clients/search/__init__.py
+++ b/core/clients/search/__init__.py
@@ -1,4 +1,5 @@
 from .base_search_client import BaseSearchClient, SearchResponse
+from .crw_client import CrwClient
 from .exa_client import ExaClient
 from .firecrawl_client import FirecrawlClient
 
@@ -6,5 +7,6 @@ __all__ = [
     "BaseSearchClient",
     "SearchResponse",
     "FirecrawlClient",
+    "CrwClient",
     "ExaClient",
 ]

--- a/core/clients/search/crw_client.py
+++ b/core/clients/search/crw_client.py
@@ -1,0 +1,70 @@
+import asyncio
+import os
+from typing import Optional
+
+from firecrawl import FirecrawlApp
+from firecrawl.firecrawl import ScrapeOptions
+
+from .base_search_client import BaseSearchClient, SearchResponse
+
+# fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or cloud).
+# It exposes a Firecrawl-compatible REST API, so the cleanest integration is to
+# reuse the Firecrawl SDK pointed at the fastCRW base URL.
+DEFAULT_CRW_API_URL = "https://fastcrw.com/api"
+
+
+class CrwClient(BaseSearchClient):
+    """fastCRW implementation of the search client (Firecrawl-compatible)."""
+
+    def __init__(self, api_key: str = "", api_url: Optional[str] = None, rate_limit: int = 1):
+        api_key = api_key or os.getenv("CRW_API_KEY", "")
+        api_url = api_url or DEFAULT_CRW_API_URL
+        super().__init__(api_key, api_url, rate_limit)
+        self.app = FirecrawlApp(api_key=api_key, api_url=api_url)
+
+    async def search(self, query: str, timeout: int = 15000) -> SearchResponse:
+        """Search using the fastCRW (Firecrawl-compatible) SDK in a thread pool to keep it async."""
+        try:
+            # Apply rate limiting
+            await self._apply_rate_limiting()
+
+            # Create ScrapeOptions object instead of passing raw dict
+            scrape_options = ScrapeOptions(formats=["markdown"])
+
+            # Run the synchronous SDK call in a thread pool
+            response = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: self.app.search(query=query, scrape_options=scrape_options),
+            )
+
+            # Handle the response format from the SDK
+            if isinstance(response, dict) and "data" in response:
+                # Response is already in the right format
+                return response
+            elif isinstance(response, dict) and "success" in response:
+                # Response is in the documented format
+                return {"data": response.get("data", [])}
+            elif isinstance(response, list):
+                # Response is a list of results
+                formatted_data = []
+                for item in response:
+                    if isinstance(item, dict):
+                        formatted_data.append(item)
+                    else:
+                        # Handle non-dict items (like objects)
+                        formatted_data.append(
+                            {
+                                "url": getattr(item, "url", ""),
+                                "markdown": getattr(item, "markdown", "") or getattr(item, "content", ""),
+                                "title": getattr(item, "title", "") or getattr(item, "metadata", {}).get("title", ""),
+                            }
+                        )
+                return {"data": formatted_data}
+            else:
+                print(f"Unexpected response format from fastCRW: {type(response)}")
+                return {"data": []}
+
+        except Exception as e:
+            print(f"Error searching with fastCRW: {e}")
+            print(f"Response type: {type(response) if 'response' in locals() else 'N/A'}")
+            return {"data": []}

--- a/core/clients/search_client.py
+++ b/core/clients/search_client.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from .search.base_search_client import BaseSearchClient, SearchResponse
+from .search.crw_client import CrwClient
 from .search.duckduckgo_client import DuckDuckGoClient
 from .search.exa_client import ExaClient
 from .search.firecrawl_client import FirecrawlClient
@@ -17,7 +18,7 @@ class SearchClient(BaseSearchClient):
         Initialize a search client of the specified type.
 
         Args:
-            client_type: Type of search client to use ('firecrawl', 'exa', 'duckduckgo', etc.)
+            client_type: Type of search client to use ('firecrawl', 'crw', 'exa', 'duckduckgo', etc.)
             api_key: API key for the search service
             api_url: Optional custom API URL
             rate_limit: Rate limit in seconds between requests
@@ -27,6 +28,8 @@ class SearchClient(BaseSearchClient):
         # Create the appropriate client implementation
         if client_type.lower() == "firecrawl":
             self._implementation = FirecrawlClient(api_key=api_key, api_url=api_url, rate_limit=rate_limit)
+        elif client_type.lower() == "crw":
+            self._implementation = CrwClient(api_key=api_key, api_url=api_url, rate_limit=rate_limit)
         elif client_type.lower() == "exa":
             self._implementation = ExaClient(api_key=api_key, api_url=api_url, rate_limit=rate_limit)
         elif client_type.lower() == "duckduckgo":


### PR DESCRIPTION
## What
Adds **fastCRW** as a web scrape/search provider, alongside the existing Firecrawl integration — additive, mirrors the Firecrawl wiring (Firecrawl untouched).

## Why
[fastCRW](https://fastcrw.com) is a fully open-source web engine (AGPL, single ~8MB Rust binary) that outperforms Firecrawl on Firecrawl's own benchmark dataset and runs entirely on-prem without any cloud dependency.

**Runs 100% locally with no cloud gates.** Anti-bot/stealth (Cloudflare JS-challenge handling), BYO-proxy + rotation, UA rotation, SPA rendering, and an HTTP→headless→proxy fallback ladder all ship in the open core. Firecrawl's OSS self-host cannot reach protected or JS-heavy sites because its stealth engine (`fire-engine`) is gated behind a cloud-only flag; fastCRW's self-host has no such limitation.

**Faster and higher-recall on Firecrawl's own benchmark.** truth-recall 63.74% vs 56.04%, with lower median latency (p50 ~1.9s vs ~2.3s). ~6MB RAM at idle. No multi-service stack — one binary.

**Search built on SearXNG, not instead of it.** fastCRW is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator underneath; fastCRW adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable with configurable engines.

Flat pricing (1 credit = 1 page; no 4x stealth surcharge, no billed-on-failure). Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported.

Because fastCRW exposes a Firecrawl-compatible API, the integration is a small additive diff — the existing Firecrawl wiring is untouched. Happy to adjust to your conventions — I maintain the integration and can provide free credits to evaluate.
